### PR TITLE
ISO19111: remove PROJ.5 specific format for CRS (refs #1214)

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -502,9 +502,6 @@ class PROJ_GCC_DLL DerivedCRS : virtual public SingleCRS {
 
     PROJ_INTERNAL void setDerivingConversionCRS();
 
-    PROJ_INTERNAL void baseExportToPROJString(
-        io::PROJStringFormatter *formatter) const; // throw(FormattingException)
-
     PROJ_INTERNAL void baseExportToWKT(
         io::WKTFormatter *&formatter, const std::string &keyword,
         const std::string &baseKeyword) const; // throw(FormattingException)
@@ -977,9 +974,6 @@ class PROJ_GCC_DLL DerivedGeodeticCRS final : public GeodeticCRS,
                        const cs::SphericalCSNNPtr &csIn);
     PROJ_INTERNAL DerivedGeodeticCRS(const DerivedGeodeticCRS &other);
 
-    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
-        const override; // throw(FormattingException)
-
     PROJ_INTERNAL CRSNNPtr _shallowClone() const override;
 
     PROJ_INTERNAL bool
@@ -989,6 +983,10 @@ class PROJ_GCC_DLL DerivedGeodeticCRS final : public GeodeticCRS,
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;
+
+    // cppcheck-suppress functionStatic
+    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
+        const override; // throw(FormattingException)
 
     INLINED_MAKE_SHARED
 
@@ -1041,9 +1039,6 @@ class PROJ_GCC_DLL DerivedGeographicCRS final : public GeographicCRS,
                          const cs::EllipsoidalCSNNPtr &csIn);
     PROJ_INTERNAL DerivedGeographicCRS(const DerivedGeographicCRS &other);
 
-    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
-        const override; // throw(FormattingException)
-
     PROJ_INTERNAL CRSNNPtr _shallowClone() const override;
 
     PROJ_INTERNAL bool
@@ -1053,6 +1048,10 @@ class PROJ_GCC_DLL DerivedGeographicCRS final : public GeographicCRS,
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;
+
+    // cppcheck-suppress functionStatic
+    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
+        const override; // throw(FormattingException)
 
     INLINED_MAKE_SHARED
 
@@ -1078,9 +1077,7 @@ using DerivedProjectedCRSNNPtr = util::nn<DerivedProjectedCRSPtr>;
  *
  * \remark Implements DerivedProjectedCRS from \ref ISO_19111_2018
  */
-class PROJ_GCC_DLL DerivedProjectedCRS final
-    : public DerivedCRS,
-      public io::IPROJStringExportable {
+class PROJ_GCC_DLL DerivedProjectedCRS final : public DerivedCRS {
   public:
     //! @cond Doxygen_Suppress
     PROJ_DLL ~DerivedProjectedCRS() override;
@@ -1105,9 +1102,6 @@ class PROJ_GCC_DLL DerivedProjectedCRS final
                         const operation::ConversionNNPtr &derivingConversionIn,
                         const cs::CoordinateSystemNNPtr &csIn);
     PROJ_INTERNAL DerivedProjectedCRS(const DerivedProjectedCRS &other);
-
-    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
-        const override; // throw(FormattingException)
 
     PROJ_INTERNAL CRSNNPtr _shallowClone() const override;
 
@@ -1164,9 +1158,6 @@ class PROJ_GCC_DLL DerivedVerticalCRS final : public VerticalCRS,
                        const cs::VerticalCSNNPtr &csIn);
     PROJ_INTERNAL DerivedVerticalCRS(const DerivedVerticalCRS &other);
 
-    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
-        const override; // throw(FormattingException)
-
     PROJ_INTERNAL CRSNNPtr _shallowClone() const override;
 
     PROJ_INTERNAL bool
@@ -1176,6 +1167,10 @@ class PROJ_GCC_DLL DerivedVerticalCRS final : public VerticalCRS,
 
     PROJ_INTERNAL std::list<std::pair<CRSNNPtr, int>>
     _identify(const io::AuthorityFactoryPtr &authorityFactory) const override;
+
+    // cppcheck-suppress functionStatic
+    PROJ_INTERNAL void _exportToPROJString(io::PROJStringFormatter *formatter)
+        const override; // throw(FormattingException)
 
     INLINED_MAKE_SHARED
 

--- a/include/proj/internal/coordinateoperation_constants.hpp
+++ b/include/proj/internal/coordinateoperation_constants.hpp
@@ -1240,7 +1240,7 @@ static const MethodMapping otherMethodMappings[] = {
 };
 
 // end of anonymous namespace
-}
+} // namespace
 
 // ---------------------------------------------------------------------------
 

--- a/include/proj/internal/esri_projection_mappings.hpp
+++ b/include/proj/internal/esri_projection_mappings.hpp
@@ -880,7 +880,7 @@ static const ESRIMethodMapping esriMappings[] = {
 // ---------------------------------------------------------------------------
 
 // end of anonymous namespace
-}
+} // namespace
 
 //! @endcond
 

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -371,7 +371,9 @@ class PROJ_GCC_DLL PROJStringFormatter {
         //! @cond Doxygen_Suppress
 
         PROJ_DLL void
-        startInversion();
+        setCRSExport(bool b);
+    PROJ_INTERNAL bool getCRSExport() const;
+    PROJ_DLL void startInversion();
     PROJ_DLL void stopInversion();
     PROJ_INTERNAL bool isInverted() const;
     PROJ_INTERNAL bool getUseETMercForTMerc(bool &settingSetOut) const;
@@ -508,24 +510,15 @@ class PROJ_GCC_DLL IPROJStringExportable {
     /** \brief Builds a PROJ string representation.
      *
      * <ul>
-     * <li>For PROJStringFormatter::Convention::PROJ_5 (the default), return
-     * strings that generally express PROJ.5 pipelines.
+     * <li>For PROJStringFormatter::Convention::PROJ_5 (the default),
      * <ul>
-     * <li>For a crs::GeographicCRS, returns a string expressing the
-     * transformation from geographic coordinates expressed in radian with
-     * longitude, latitude order, and with respect to the international
-     * reference meridian, into geographic coordinates expressed in the units
-     * and axis order of the CRS, taking into account its prime meridian.</li>
-     * <li>For a geocentric crs::GeodeticCRS, returns a string expressing the
-     * transformation from geographic coordinates expressed in radian with
-     * longitude, latitude order, and with respect to the international
-     * reference meridian, into geocentric coordinates.</li>
-     * <li>For a
-     * crs::ProjectedCRS / crs::DerivedGeographicCRS / crs::DerivedProjectedCRS,
-     * returns a string expressing the transformation from the base CRS to the
-     * CRS</li>
-     * <li>For a crs::BoundCRS, throws a FormattingException.</li>
-     * <li>For operation::CoordinateTransformations, returns a PROJ
+     * <li>For a crs::CRS, returns the same as
+     * PROJStringFormatter::Convention::PROJ_4. It should be noted that the
+     * export of a CRS as a PROJ string may cause loss of many important aspects
+     * of a CRS definition. Consequently it is discouraged to use it for
+     * interoperability in newer projects. The choice of a WKT representation
+     * will be a better option.</li>
+     * <li>For operation::CoordinateOperation, returns a PROJ
      * pipeline.</li>
      * </ul>
      *

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -61,7 +61,6 @@ namespace { // anonymous namespace
 struct OutputOptions {
     bool quiet = false;
     bool PROJ5 = false;
-    bool PROJ4 = false;
     bool WKT2_2018 = false;
     bool WKT2_2018_SIMPLIFIED = false;
     bool WKT2_2015 = false;
@@ -100,7 +99,7 @@ static void usage() {
         << std::endl;
     std::cerr << std::endl;
     std::cerr << "-o: formats is a comma separated combination of: "
-                 "all,default,PROJ4,PROJ,WKT_ALL,WKT2_2015,WKT2_2018,WKT1_GDAL,"
+                 "all,default,PROJ,WKT_ALL,WKT2_2015,WKT2_2018,WKT1_GDAL,"
                  "WKT1_ESRI"
               << std::endl;
     std::cerr << "    Except 'all' and 'default', other format can be preceded "
@@ -256,29 +255,11 @@ static void outputObject(DatabaseContextPtr dbContext, BaseObjectNNPtr obj,
     if (projStringExportable) {
         if (outputOpt.PROJ5) {
             try {
-                if (!outputOpt.quiet) {
-                    std::cout << "PROJ string:" << std::endl;
-                }
-                std::cout << projStringExportable->exportToPROJString(
-                                 PROJStringFormatter::create(
-                                     PROJStringFormatter::Convention::PROJ_5,
-                                     dbContext)
-                                     .get())
-                          << std::endl;
-            } catch (const std::exception &e) {
-                std::cerr << "Error when exporting to PROJ string: " << e.what()
-                          << std::endl;
-            }
-            alreadyOutputed = true;
-        }
-
-        if (outputOpt.PROJ4) {
-            try {
                 if (alreadyOutputed) {
                     std::cout << std::endl;
                 }
                 if (!outputOpt.quiet) {
-                    std::cout << "PROJ.4 string:" << std::endl;
+                    std::cout << "PROJ string:" << std::endl;
                 }
 
                 auto crs = nn_dynamic_pointer_cast<CRS>(obj);
@@ -295,7 +276,7 @@ static void outputObject(DatabaseContextPtr dbContext, BaseObjectNNPtr obj,
 
                 std::cout << objToExport->exportToPROJString(
                                  PROJStringFormatter::create(
-                                     PROJStringFormatter::Convention::PROJ_4,
+                                     PROJStringFormatter::Convention::PROJ_5,
                                      dbContext)
                                      .get())
                           << std::endl;
@@ -651,23 +632,15 @@ int main(int argc, char **argv) {
             for (auto format : formats) {
                 if (ci_equal(format, "all")) {
                     outputOpt.PROJ5 = true;
-                    outputOpt.PROJ4 = true;
                     outputOpt.WKT2_2018 = true;
                     outputOpt.WKT2_2015 = true;
                     outputOpt.WKT1_GDAL = true;
                     outputOpt.WKT1_ESRI = true;
                 } else if (ci_equal(format, "default")) {
                     outputOpt.PROJ5 = true;
-                    outputOpt.PROJ4 = false;
                     outputOpt.WKT2_2018 = false;
                     outputOpt.WKT2_2015 = true;
                     outputOpt.WKT1_GDAL = false;
-                } else if (ci_equal(format, "PROJ4") ||
-                           ci_equal(format, "PROJ.4")) {
-                    outputOpt.PROJ4 = true;
-                } else if (ci_equal(format, "-PROJ4") ||
-                           ci_equal(format, "-PROJ.4")) {
-                    outputOpt.PROJ4 = false;
                 } else if (ci_equal(format, "PROJ")) {
                     outputOpt.PROJ5 = true;
                 } else if (ci_equal(format, "-PROJ")) {
@@ -929,7 +902,7 @@ int main(int argc, char **argv) {
     }
 
     if (outputOpt.quiet &&
-        (outputOpt.PROJ5 + outputOpt.PROJ4 + outputOpt.WKT2_2018 +
+        (outputOpt.PROJ5 + outputOpt.WKT2_2018 +
          outputOpt.WKT2_2015 + outputOpt.WKT1_GDAL) != 1) {
         std::cerr << "-q can only be used with a single output format"
                   << std::endl;

--- a/src/apps/projinfo.cpp
+++ b/src/apps/projinfo.cpp
@@ -258,11 +258,15 @@ static void outputObject(DatabaseContextPtr dbContext, BaseObjectNNPtr obj,
                 if (alreadyOutputed) {
                     std::cout << std::endl;
                 }
+                auto crs = nn_dynamic_pointer_cast<CRS>(obj);
                 if (!outputOpt.quiet) {
-                    std::cout << "PROJ string:" << std::endl;
+                    if( crs ) {
+                        std::cout << "PROJ.4 string:" << std::endl;
+                    } else {
+                        std::cout << "PROJ string:" << std::endl;
+                    }
                 }
 
-                auto crs = nn_dynamic_pointer_cast<CRS>(obj);
                 std::shared_ptr<IPROJStringExportable> objToExport;
                 if (crs) {
                     objToExport =

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -3757,13 +3757,6 @@ void BoundCRS::_exportToWKT(io::WKTFormatter *formatter) const {
 void BoundCRS::_exportToPROJString(
     io::PROJStringFormatter *formatter) const // throw(io::FormattingException)
 {
-    if (formatter->convention() ==
-        io::PROJStringFormatter::Convention::PROJ_5) {
-        io::FormattingException::Throw(
-            "BoundCRS cannot be exported as a PROJ.5 string, but its baseCRS "
-            "might");
-    }
-
     auto crs_exportable =
         dynamic_cast<const io::IPROJStringExportable *>(d->baseCRS_.get());
     if (!crs_exportable) {

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -4596,14 +4596,18 @@ IPROJStringExportable::~IPROJStringExportable() = default;
 
 std::string IPROJStringExportable::exportToPROJString(
     PROJStringFormatter *formatter) const {
+    const bool bIsCRS = dynamic_cast<const crs::CRS *>(this) != nullptr;
+    if (bIsCRS) {
+        formatter->setCRSExport(true);
+    }
     _exportToPROJString(formatter);
-    if (formatter->getAddNoDefs() &&
-        formatter->convention() ==
-            io::PROJStringFormatter::Convention::PROJ_4 &&
-        dynamic_cast<const crs::CRS *>(this)) {
+    if (formatter->getAddNoDefs() && bIsCRS) {
         if (!formatter->hasParam("no_defs")) {
             formatter->addParam("no_defs");
         }
+    }
+    if (bIsCRS) {
+        formatter->setCRSExport(false);
     }
     return formatter->toString();
 }
@@ -4673,6 +4677,7 @@ struct PROJStringFormatter::Private {
     bool useETMercForTMercSet_ = false;
     bool addNoDefs_ = true;
     bool coordOperationOptimizations_ = false;
+    bool crsExport_ = false;
 
     std::string result_{};
 
@@ -5308,6 +5313,14 @@ void PROJStringFormatter::ingestPROJString(
                            vto_meter);
     d->steps_.insert(d->steps_.end(), steps.begin(), steps.end());
 }
+
+// ---------------------------------------------------------------------------
+
+void PROJStringFormatter::setCRSExport(bool b) { d->crsExport_ = b; }
+
+// ---------------------------------------------------------------------------
+
+bool PROJStringFormatter::getCRSExport() const { return d->crsExport_; }
 
 // ---------------------------------------------------------------------------
 

--- a/test/cli/testprojinfo
+++ b/test/cli/testprojinfo
@@ -82,6 +82,10 @@ echo "Testing non compliant WKT1" >> ${OUT}
 $EXE 'GEOGCS["WGS 84",DATUM["WGS_1984",SPHEROID["WGS 84",6378137,298.257223563]],UNIT["degree",0.0174532925199433]]' >>${OUT} 2>&1
 echo "" >>${OUT}
 
+echo "Testing CRS with towgs84: projinfo -o PROJ EPSG:25832" >> ${OUT}
+$EXE -o PROJ EPSG:25832 >>${OUT} 2>&1
+echo "" >>${OUT}
+
 # do 'diff' with distribution results
 echo "diff ${OUT} with testprojinfo_out.dist"
 diff -u ${OUT} ${TEST_CLI_DIR}/testprojinfo_out.dist

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1,5 +1,5 @@
 Testing projinfo EPSG:4326
-PROJ string:
+PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
@@ -21,7 +21,7 @@ GEODCRS["WGS 84",
     ID["EPSG",4326]]
 
 Testing projinfo -o ALL EPSG:4326
-PROJ string:
+PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
@@ -480,7 +480,7 @@ Warning: object is deprecated
 Alternative non-deprecated CRS:
   EPSG:3003
 
-PROJ string:
+PROJ.4 string:
 +proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +pm=rome +units=m +no_defs
 
 WKT2_2015 string:
@@ -525,7 +525,7 @@ Warning: GEOGCS should have a PRIMEM node
 Warning: Parsing error : syntax error, unexpected UNIT, expecting PRIMEM. Error occurred around:
 HEROID["WGS 84",6378137,298.257223563]],UNIT["degree",0.0174532925199433]]
                                         ^
-PROJ string:
+PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
@@ -544,4 +544,8 @@ GEODCRS["WGS 84",
         AXIS["latitude",north,
             ORDER[2],
             ANGLEUNIT["degree",0.0174532925199433]]]
+
+Testing CRS with towgs84: projinfo -o PROJ EPSG:25832
+PROJ.4 string:
++proj=utm +zone=32 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
 

--- a/test/cli/testprojinfo_out.dist
+++ b/test/cli/testprojinfo_out.dist
@@ -1,6 +1,6 @@
 Testing projinfo EPSG:4326
 PROJ string:
-+proj=pipeline +step +proj=longlat +ellps=WGS84 +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
++proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
 GEODCRS["WGS 84",
@@ -22,9 +22,6 @@ GEODCRS["WGS 84",
 
 Testing projinfo -o ALL EPSG:4326
 PROJ string:
-+proj=pipeline +step +proj=longlat +ellps=WGS84 +step +proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap +order=2,1
-
-PROJ.4 string:
 +proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
@@ -484,7 +481,7 @@ Alternative non-deprecated CRS:
   EPSG:3003
 
 PROJ string:
-+proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=unitconvert +xy_in=deg +xy_out=rad +step +inv +proj=longlat +ellps=intl +pm=rome +step +proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +pm=rome
++proj=tmerc +lat_0=0 +lon_0=9 +k=0.9996 +x_0=1500000 +y_0=0 +ellps=intl +pm=rome +units=m +no_defs
 
 WKT2_2015 string:
 PROJCRS["Monte Mario (Rome) / Italy zone 1",
@@ -529,7 +526,7 @@ Warning: Parsing error : syntax error, unexpected UNIT, expecting PRIMEM. Error 
 HEROID["WGS 84",6378137,298.257223563]],UNIT["degree",0.0174532925199433]]
                                         ^
 PROJ string:
-+proj=pipeline +step +proj=longlat +ellps=WGS84 +step +proj=unitconvert +xy_in=rad +xy_out=deg
++proj=longlat +datum=WGS84 +no_defs
 
 WKT2_2015 string:
 GEODCRS["WGS 84",

--- a/test/unit/proj_angular_io_test.cpp
+++ b/test/unit/proj_angular_io_test.cpp
@@ -48,7 +48,9 @@ TEST(AngularUnits, Basic) {
 
 TEST(AngularUnits, Pipelines) {
     auto ctx = proj_context_create();
-    auto P = proj_create(ctx, "proj=pipeline +step +proj=axisswap +order=2,1 +step +proj=latlong +step +proj=axisswap +order=2,1");
+    auto P =
+        proj_create(ctx, "proj=pipeline +step +proj=axisswap +order=2,1 +step "
+                         "+proj=latlong +step +proj=axisswap +order=2,1");
 
     EXPECT_TRUE(proj_angular_input(P, PJ_FWD));
     EXPECT_TRUE(proj_angular_output(P, PJ_FWD));
@@ -57,45 +59,43 @@ TEST(AngularUnits, Pipelines) {
 
     proj_destroy(P);
     proj_context_destroy(ctx);
-
 }
 
 TEST(AngularUnits, Pipelines2) {
     auto ctx = proj_context_create();
     auto P = proj_create(
-            ctx,
-            "+proj=pipeline "
-            "+step +proj=axisswap +order=2,1 "
-            "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
-            "+step +proj=tmerc +lat_0=0 +lon_0=-81 +k=0.9996 +x_0=500000.001016002 +y_0=0 +ellps=WGS84 "
-            "+step +proj=axisswap +order=2,1 "
-            "+step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft");
+        ctx,
+        "+proj=pipeline "
+        "+step +proj=axisswap +order=2,1 "
+        "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
+        "+step +proj=tmerc +lat_0=0 +lon_0=-81 +k=0.9996 +x_0=500000.001016002 "
+        "+y_0=0 +ellps=WGS84 "
+        "+step +proj=axisswap +order=2,1 "
+        "+step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft");
 
     EXPECT_FALSE(proj_angular_input(P, PJ_FWD));
     EXPECT_FALSE(proj_angular_output(P, PJ_FWD));
 
     proj_destroy(P);
     proj_context_destroy(ctx);
-
 }
 
 TEST(AngularUnits, Pipelines3) {
     auto ctx = proj_context_create();
     auto P = proj_create(
-            ctx,
-            "+proj=pipeline "
-            "+step +proj=axisswap +order=2,1 "
-            "+step +proj=tmerc +lat_0=0 +lon_0=-81 +k=0.9996 +x_0=500000.001016002 +y_0=0 +ellps=WGS84 "
-            "+step +proj=axisswap +order=2,1 "
-            "+step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft");
+        ctx,
+        "+proj=pipeline "
+        "+step +proj=axisswap +order=2,1 "
+        "+step +proj=tmerc +lat_0=0 +lon_0=-81 +k=0.9996 +x_0=500000.001016002 "
+        "+y_0=0 +ellps=WGS84 "
+        "+step +proj=axisswap +order=2,1 "
+        "+step +proj=unitconvert +xy_in=m +z_in=m +xy_out=us-ft +z_out=us-ft");
 
     EXPECT_TRUE(proj_angular_input(P, PJ_FWD));
     EXPECT_FALSE(proj_angular_output(P, PJ_FWD));
 
     proj_destroy(P);
     proj_context_destroy(ctx);
-
 }
-
 
 } // namespace

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -492,10 +492,7 @@ TEST_F(CApi, proj_as_proj_string) {
     {
         auto proj_5 = proj_as_proj_string(m_ctxt, obj, PJ_PROJ_5, nullptr);
         ASSERT_NE(proj_5, nullptr);
-        EXPECT_EQ(std::string(proj_5), "+proj=pipeline +step +proj=longlat "
-                                       "+ellps=WGS84 +step +proj=unitconvert "
-                                       "+xy_in=rad +xy_out=deg +step "
-                                       "+proj=axisswap +order=2,1");
+        EXPECT_EQ(std::string(proj_5), "+proj=longlat +datum=WGS84 +no_defs");
     }
     {
         auto proj_4 = proj_as_proj_string(m_ctxt, obj, PJ_PROJ_4, nullptr);

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -3539,13 +3539,8 @@ TEST(crs, boundCRS_geographicCRS_to_PROJ_string) {
     auto crs = BoundCRS::createFromTOWGS84(
         basecrs, std::vector<double>{1, 2, 3, 4, 5, 6, 7});
 
-    EXPECT_THROW(crs->exportToPROJString(PROJStringFormatter::create().get()),
-                 FormattingException);
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=longlat +ellps=WGS84 +towgs84=1,2,3,4,5,6,7 +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=longlat +ellps=WGS84 +towgs84=1,2,3,4,5,6,7 +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -3564,12 +3559,9 @@ TEST(crs, boundCRS_projectedCRS_to_PROJ_string) {
     auto crs = BoundCRS::createFromTOWGS84(
         projcrs, std::vector<double>{1, 2, 3, 4, 5, 6, 7});
 
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=utm +zone=31 +ellps=WGS84 +towgs84=1,2,3,4,5,6,7 +units=m "
-        "+no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=utm +zone=31 +ellps=WGS84 +towgs84=1,2,3,4,5,6,7 +units=m "
+              "+no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -3695,12 +3687,9 @@ TEST(crs, WKT1_DATUM_EXTENSION_to_WKT1_and_PROJ_string) {
             WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL).get()),
         wkt);
 
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 "
-        "+ellps=intl +nadgrids=nzgd2kgrid0005.gsb +units=m +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=nzmg +lat_0=-41 +lon_0=173 +x_0=2510000 +y_0=6023150 "
+              "+ellps=intl +nadgrids=nzgd2kgrid0005.gsb +units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -3796,11 +3785,8 @@ TEST(crs, WKT1_VERT_DATUM_EXTENSION_to_PROJ_string) {
     auto crs = nn_dynamic_pointer_cast<BoundCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
 
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+geoidgrids=egm08_25.gtx +vunits=m +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+geoidgrids=egm08_25.gtx +vunits=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -4756,14 +4742,12 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
                   bound);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 "
-                  "+y_0=500000 +ellps=krass "
-                  "+towgs84=2.329,-147.042,-92.08,-0.309,0.325,0.497,5.69 "
-                  "+units=m +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=sterea +lat_0=46 +lon_0=25 +k=0.99975 +x_0=500000 "
+            "+y_0=500000 +ellps=krass "
+            "+towgs84=2.329,-147.042,-92.08,-0.309,0.325,0.497,5.69 "
+            "+units=m +no_defs");
     }
     {
         // Pulkovo 42 Poland
@@ -4775,14 +4759,12 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
                   bound);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=sterea +lat_0=50.625 +lon_0=21.0833333333333 "
-                  "+k=0.9998 +x_0=4637000 +y_0=5647000 +ellps=krass "
-                  "+towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 "
-                  "+units=m +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=sterea +lat_0=50.625 +lon_0=21.0833333333333 "
+            "+k=0.9998 +x_0=4637000 +y_0=5647000 +ellps=krass "
+            "+towgs84=33.4,-146.6,-76.3,-0.359,-0.053,0.844,-0.84 "
+            "+units=m +no_defs");
     }
     {
         // NTF (Paris)
@@ -4794,12 +4776,10 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
                   bound);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=longlat +ellps=clrk80ign +pm=paris "
-                  "+towgs84=-168,-60,320,0,0,0,0 +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=longlat +ellps=clrk80ign +pm=paris "
+            "+towgs84=-168,-60,320,0,0,0,0 +no_defs");
     }
     {
         // NTF (Paris) / Lambert zone II + NGF-IGN69 height
@@ -4811,14 +4791,12 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
                   bound);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 "
-                  "+x_0=600000 +y_0=2200000 +ellps=clrk80ign +pm=paris "
-                  "+towgs84=-168,-60,320,0,0,0,0 +units=m "
-                  "+vunits=m +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=lcc +lat_1=46.8 +lat_0=46.8 +lon_0=0 +k_0=0.99987742 "
+            "+x_0=600000 +y_0=2200000 +ellps=clrk80ign +pm=paris "
+            "+towgs84=-168,-60,320,0,0,0,0 +units=m "
+            "+vunits=m +no_defs");
     }
     {
         auto crs = createVerticalCRS();
@@ -4832,13 +4810,11 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
         EXPECT_NE(bound, crs);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=stere +lat_0=-90 +lon_0=140 +k=0.960272946 "
-                  "+x_0=300000 +y_0=-2299363.482 +ellps=intl "
-                  "+towgs84=324.8,153.6,172.1,0,0,0,0 +units=m +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=stere +lat_0=-90 +lon_0=140 +k=0.960272946 "
+            "+x_0=300000 +y_0=-2299363.482 +ellps=intl "
+            "+towgs84=324.8,153.6,172.1,0,0,0,0 +units=m +no_defs");
     }
     {
         auto factoryIGNF =
@@ -4848,12 +4824,10 @@ TEST(crs, crs_createBoundCRSToWGS84IfPossible) {
         EXPECT_NE(bound, crs);
         auto boundCRS = nn_dynamic_pointer_cast<BoundCRS>(bound);
         ASSERT_TRUE(boundCRS != nullptr);
-        EXPECT_EQ(boundCRS->exportToPROJString(
-                      PROJStringFormatter::create(
-                          PROJStringFormatter::Convention::PROJ_4)
-                          .get()),
-                  "+proj=geocent +ellps=intl "
-                  "+towgs84=324.8,153.6,172.1,0,0,0,0 +units=m +no_defs");
+        EXPECT_EQ(
+            boundCRS->exportToPROJString(PROJStringFormatter::create().get()),
+            "+proj=geocent +ellps=intl "
+            "+towgs84=324.8,153.6,172.1,0,0,0,0 +units=m +no_defs");
     }
     {
         auto crs = factory->createCoordinateReferenceSystem("4269"); // NAD83

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -388,14 +388,7 @@ TEST(crs, EPSG_4326_as_WKT1_ESRI_without_database) {
 TEST(crs, EPSG_4326_as_PROJ_string) {
     auto crs = GeographicCRS::EPSG_4326;
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=longlat +ellps=WGS84 +step "
-              "+proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap "
-              "+order=2,1");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=longlat +datum=WGS84 +no_defs");
+              "+proj=longlat +datum=WGS84 +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -595,14 +588,7 @@ TEST(crs, EPSG_4807_as_WKT1_ESRI_without_database) {
 TEST(crs, EPSG_4807_as_PROJ_string) {
     auto crs = GeographicCRS::EPSG_4807;
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=longlat +ellps=clrk80ign "
-              "+pm=paris +step +proj=unitconvert +xy_in=rad +xy_out=grad +step "
-              "+proj=axisswap +order=2,1");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=longlat +ellps=clrk80ign +pm=paris +no_defs");
+              "+proj=longlat +ellps=clrk80ign +pm=paris +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -624,11 +610,8 @@ TEST(crs, EPSG_4267) {
               "            ORDER[2],\n"
               "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
               "    ID[\"EPSG\",4267]]");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=longlat +datum=NAD27 +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=longlat +datum=NAD27 +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -663,11 +646,8 @@ TEST(crs, EPSG_4269) {
               "            ORDER[2],\n"
               "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
               "    ID[\"EPSG\",4269]]");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=longlat +datum=NAD83 +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=longlat +datum=NAD83 +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -725,15 +705,6 @@ TEST(crs, EPSG_27561_projected_with_geodetic_in_grad_as_PROJ_string_and_WKT1) {
     ASSERT_TRUE(crs != nullptr);
     EXPECT_EQ(
         crs->exportToPROJString(PROJStringFormatter::create().get()),
-        "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-        "+proj=unitconvert +xy_in=grad +xy_out=rad +step +inv +proj=longlat "
-        "+ellps=clrk80ign +pm=paris +step +proj=lcc +lat_1=49.5 "
-        "+lat_0=49.5 +lon_0=0 +k_0=0.999877341 +x_0=600000 +y_0=200000 "
-        "+ellps=clrk80ign +pm=paris");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
         "+proj=lcc +lat_1=49.5 +lat_0=49.5 +lon_0=0 +k_0=0.999877341 "
         "+x_0=600000 +y_0=200000 +ellps=clrk80ign +pm=paris +units=m +no_defs");
 
@@ -811,9 +782,7 @@ TEST(crs, EPSG_3040_projected_northing_easting_as_PROJ_string) {
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=utm "
-              "+zone=28 +ellps=GRS80 +step +proj=axisswap +order=2,1");
+              "+proj=utm +zone=28 +ellps=GRS80 +units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -843,17 +812,8 @@ TEST(crs, EPSG_2222_projected_unit_foot_as_PROJ_string_and_WKT1) {
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=tmerc "
-              "+lat_0=31 +lon_0=-110.166666666667 +k=0.9999 +x_0=213360 "
-              "+y_0=0 +ellps=GRS80 +step +proj=unitconvert +xy_in=m +z_in=m "
-              "+xy_out=ft +z_out=ft");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=tmerc +lat_0=31 +lon_0=-110.166666666667 +k=0.9999 "
-        "+x_0=213360 +y_0=0 +datum=NAD83 +units=ft +no_defs");
+              "+proj=tmerc +lat_0=31 +lon_0=-110.166666666667 +k=0.9999 "
+              "+x_0=213360 +y_0=0 +datum=NAD83 +units=ft +no_defs");
 
     auto wkt1 = crs->exportToWKT(
         WKTFormatter::create(WKTFormatter::Convention::WKT1_GDAL).get());
@@ -931,22 +891,18 @@ TEST(crs, EPSG_32661_projected_north_pole_north_east) {
     auto crs = factory->createCoordinateReferenceSystem("32661");
     auto proj_crs = nn_dynamic_pointer_cast<ProjectedCRS>(crs);
     ASSERT_TRUE(proj_crs != nullptr);
+
     auto proj_string =
         "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
         "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere "
         "+lat_0=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
         "+ellps=WGS84 +step +proj=axisswap +order=2,1";
-    EXPECT_EQ(proj_crs->exportToPROJString(PROJStringFormatter::create().get()),
-              proj_string);
 
-    auto obj_from_proj = PROJStringParser().createFromPROJString(proj_string);
-    auto crs_from_proj = nn_dynamic_pointer_cast<ProjectedCRS>(obj_from_proj);
-    ASSERT_TRUE(crs_from_proj != nullptr);
-    EXPECT_EQ(
-        crs_from_proj->exportToPROJString(PROJStringFormatter::create().get()),
-        proj_string);
-    EXPECT_TRUE(crs_from_proj->coordinateSystem()->isEquivalentTo(
-        proj_crs->coordinateSystem().get()));
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, NN_NO_CHECK(proj_crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              proj_string);
 }
 
 // ---------------------------------------------------------------------------
@@ -962,17 +918,12 @@ TEST(crs, EPSG_5041_projected_north_pole_east_north) {
         "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere "
         "+lat_0=90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
         "+ellps=WGS84";
-    EXPECT_EQ(proj_crs->exportToPROJString(PROJStringFormatter::create().get()),
-              proj_string);
 
-    auto obj_from_proj = PROJStringParser().createFromPROJString(proj_string);
-    auto crs_from_proj = nn_dynamic_pointer_cast<ProjectedCRS>(obj_from_proj);
-    ASSERT_TRUE(crs_from_proj != nullptr);
-    EXPECT_EQ(
-        crs_from_proj->exportToPROJString(PROJStringFormatter::create().get()),
-        proj_string);
-    EXPECT_TRUE(crs_from_proj->coordinateSystem()->isEquivalentTo(
-        proj_crs->coordinateSystem().get()));
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, NN_NO_CHECK(proj_crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              proj_string);
 }
 
 // ---------------------------------------------------------------------------
@@ -988,17 +939,12 @@ TEST(crs, EPSG_32761_projected_south_pole_north_east) {
         "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere "
         "+lat_0=-90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
         "+ellps=WGS84 +step +proj=axisswap +order=2,1";
-    EXPECT_EQ(proj_crs->exportToPROJString(PROJStringFormatter::create().get()),
-              proj_string);
 
-    auto obj_from_proj = PROJStringParser().createFromPROJString(proj_string);
-    auto crs_from_proj = nn_dynamic_pointer_cast<ProjectedCRS>(obj_from_proj);
-    ASSERT_TRUE(crs_from_proj != nullptr);
-    EXPECT_EQ(
-        crs_from_proj->exportToPROJString(PROJStringFormatter::create().get()),
-        proj_string);
-    EXPECT_TRUE(crs_from_proj->coordinateSystem()->isEquivalentTo(
-        proj_crs->coordinateSystem().get()));
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, NN_NO_CHECK(proj_crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              proj_string);
 }
 
 // ---------------------------------------------------------------------------
@@ -1009,11 +955,17 @@ TEST(crs, EPSG_5042_projected_south_pole_east_north) {
     auto crs = factory->createCoordinateReferenceSystem("5042");
     auto proj_crs = nn_dynamic_pointer_cast<ProjectedCRS>(crs);
     ASSERT_TRUE(proj_crs != nullptr);
-    EXPECT_EQ(proj_crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere "
-              "+lat_0=-90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
-              "+ellps=WGS84");
+    auto proj_string =
+        "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
+        "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=stere "
+        "+lat_0=-90 +lon_0=0 +k=0.994 +x_0=2000000 +y_0=2000000 "
+        "+ellps=WGS84";
+
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, NN_NO_CHECK(proj_crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              proj_string);
 }
 
 // ---------------------------------------------------------------------------
@@ -1157,12 +1109,7 @@ TEST(crs, EPSG_4978_as_WKT1_GDAL_with_database) {
 TEST(crs, geocentricCRS_as_PROJ_string) {
     auto crs = createGeocentric();
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=cart +ellps=WGS84");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=geocent +datum=WGS84 +units=m +no_defs");
+              "+proj=geocent +datum=WGS84 +units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -1173,14 +1120,17 @@ TEST(crs, geocentricCRS_non_meter_unit_as_PROJ_string) {
         CartesianCS::createGeocentric(
             UnitOfMeasure("kilometre", 1000.0, UnitOfMeasure::Type::LINEAR)));
 
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=cart +ellps=WGS84 +step "
-              "+proj=unitconvert +xy_in=m +z_in=m +xy_out=km +z_out=km");
-    EXPECT_THROW(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        FormattingException);
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, crs);
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
+              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=cart "
+              "+ellps=WGS84 +step +proj=unitconvert +xy_in=m +z_in=m "
+              "+xy_out=km +z_out=km");
+
+    EXPECT_THROW(crs->exportToPROJString(PROJStringFormatter::create().get()),
+                 FormattingException);
 }
 
 // ---------------------------------------------------------------------------
@@ -1191,9 +1141,14 @@ TEST(crs, geocentricCRS_unsupported_unit_as_PROJ_string) {
         CartesianCS::createGeocentric(
             UnitOfMeasure("my unit", 500.0, UnitOfMeasure::Type::LINEAR)));
 
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=cart +ellps=WGS84 +step "
-              "+proj=unitconvert +xy_in=m +z_in=m +xy_out=500 +z_out=500");
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, crs);
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
+              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=cart "
+              "+ellps=WGS84 +step +proj=unitconvert +xy_in=m +z_in=m "
+              "+xy_out=500 +z_out=500");
 }
 
 // ---------------------------------------------------------------------------
@@ -1556,7 +1511,7 @@ TEST(crs, projectedCRS_shallowClone) {
         }
         EXPECT_EQ(clone->baseCRS()->exportToPROJString(
                       PROJStringFormatter::create().get()),
-                  "+proj=cart +ellps=WGS84");
+                  "+proj=geocent +datum=WGS84 +units=m +no_defs");
     }
 }
 
@@ -1785,15 +1740,16 @@ TEST(crs, projectedCRS_from_WKT1_ESRI_as_WKT1_ESRI) {
 
 TEST(crs, projectedCRS_as_PROJ_string) {
     auto crs = createProjected();
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, crs);
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
               "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=utm "
               "+zone=31 +ellps=WGS84");
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs");
+    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=utm +zone=31 +datum=WGS84 +units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -1802,7 +1758,10 @@ TEST(crs, projectedCRS_Krovak_EPSG_5221_as_PROJ_string) {
     auto factory = AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     auto crs = factory->createProjectedCRS("5221");
     // 30deg 17' 17.30311'' = 30.28813975277777776
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        crs->baseCRS(), crs);
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline +step +proj=axisswap +order=2,1 "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +inv +proj=longlat +ellps=bessel +pm=ferro "
@@ -1819,7 +1778,10 @@ TEST(crs, projectedCRS_Krovak_with_approximate_alpha_as_PROJ_string) {
         "+proj=krovak +lat_0=49.5 +lon_0=42.5 +alpha=30.28813972222222 "
         "+k=0.9999 +x_0=0 +y_0=0 +ellps=bessel +pm=ferro +units=m +no_defs");
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        crs->baseCRS(), NN_NO_CHECK(crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=pipeline "
               "+step +proj=unitconvert +xy_in=deg +xy_out=rad "
               "+step +inv +proj=longlat +ellps=bessel +pm=ferro "
@@ -3159,17 +3121,8 @@ TEST(crs, compoundCRS_as_WKT1_GDAL) {
 
 TEST(crs, compoundCRS_as_PROJ_string) {
     auto crs = createCompoundCRS();
-    auto expected = "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-                    "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=utm "
-                    "+zone=31 +ellps=WGS84 +vunits=m";
-
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              expected);
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=utm +zone=31 +datum=WGS84 +units=m +vunits=m +no_defs");
+              "+proj=utm +zone=31 +datum=WGS84 +units=m +vunits=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -4022,8 +3975,11 @@ TEST(crs, derivedGeographicCRS_to_PROJ) {
     auto obj = WKTParser().createFromWKT(wkt);
     auto crs = nn_dynamic_pointer_cast<DerivedGeographicCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        crs->baseCRS(), NN_NO_CHECK(crs));
+    ASSERT_TRUE(op != nullptr);
     EXPECT_EQ(
-        crs->exportToPROJString(PROJStringFormatter::create().get()),
+        op->exportToPROJString(PROJStringFormatter::create().get()),
         "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
         "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=ob_tran "
         "+o_proj=longlat +o_lat_p=52 +o_lon_p=-30 +lon_0=-25 +ellps=WGS84 "
@@ -4071,7 +4027,10 @@ TEST(crs, derivedGeographicCRS_with_affine_transform_to_PROJ) {
     auto crs = nn_dynamic_pointer_cast<DerivedGeographicCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
     EXPECT_TRUE(crs->derivingConversion()->validateParameters().empty());
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        crs->baseCRS(), NN_NO_CHECK(crs));
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=affine +xoff=0.5 +s11=1 +s12=0 +yoff=2.5 +s21=0 +s22=1");
 }
 
@@ -4250,15 +4209,6 @@ TEST(crs, derivedProjectedCRS_WKT2_2015) {
         crs->exportToWKT(
             WKTFormatter::create(WKTFormatter::Convention::WKT2_2015).get()),
         FormattingException);
-}
-
-// ---------------------------------------------------------------------------
-
-TEST(crs, derivedProjectedCRS_to_PROJ) {
-
-    auto crs = createDerivedProjectedCRS();
-    EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=unimplemented");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_factory.cpp
+++ b/test/unit/test_factory.cpp
@@ -409,9 +409,7 @@ TEST(factory, AuthorityFactory_createGeodeticCRS_geographic2D) {
     EXPECT_TRUE(extent->isEquivalentTo(factory->createExtent("1262").get()));
 
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=longlat +ellps=WGS84 +step "
-              "+proj=unitconvert +xy_in=rad +xy_out=deg +step +proj=axisswap "
-              "+order=2,1");
+              "+proj=longlat +datum=WGS84 +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -972,11 +970,9 @@ TEST(factory, AuthorityFactory_test_uom_9110) {
     // This tests conversion from unit of measure EPSG:9110 DDD.MMSSsss
     auto crs = factory->createProjectedCRS("2172");
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=sterea "
-              "+lat_0=53.0019444444444 +lon_0=21.5027777777778 +k=0.9998 "
-              "+x_0=4603000 +y_0=5806000 +ellps=krass +step +proj=axisswap "
-              "+order=2,1");
+              "+proj=sterea +lat_0=53.0019444444444 +lon_0=21.5027777777778 "
+              "+k=0.9998 +x_0=4603000 +y_0=5806000 +ellps=krass +units=m "
+              "+no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -2327,10 +2323,8 @@ TEST_F(FactoryWithTmpDatabase, custom_projected_crs) {
         EXPECT_EQ(*(crs->name()->description()), "my name");
         EXPECT_EQ(crs->identifiers().size(), 1);
         EXPECT_EQ(crs->derivingConversion()->targetCRS().get(), crs.get());
-        EXPECT_EQ(
-            crs->exportToPROJString(PROJStringFormatter::create().get()),
-            "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
-            "+step +proj=mbt_s +unused_flag +ellps=WGS84");
+        EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+                  "+proj=mbt_s +unused_flag +datum=WGS84 +units=m +no_defs");
         EXPECT_TRUE(crs->canonicalBoundCRS() == nullptr);
     }
     {
@@ -2338,10 +2332,8 @@ TEST_F(FactoryWithTmpDatabase, custom_projected_crs) {
         EXPECT_EQ(*(crs->name()->description()), "my name");
         EXPECT_EQ(crs->identifiers().size(), 1);
         EXPECT_EQ(crs->derivingConversion()->targetCRS().get(), crs.get());
-        EXPECT_EQ(
-            crs->exportToPROJString(PROJStringFormatter::create().get()),
-            "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
-            "+step +proj=mbt_s +unused_flag +ellps=WGS84");
+        EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
+                  "+proj=mbt_s +unused_flag +datum=WGS84 +units=m +no_defs");
         EXPECT_TRUE(crs->canonicalBoundCRS() != nullptr);
     }
 

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -1377,9 +1377,8 @@ TEST(operation, tmerc_south_oriented_export) {
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=tmerc "
-              "+axis=wsu +lat_0=0 +lon_0=29 +k=1 +x_0=0 +y_0=0 +ellps=WGS84");
+              "+proj=tmerc +axis=wsu +lat_0=0 +lon_0=29 +k=1 +x_0=0 +y_0=0 "
+              "+ellps=WGS84 +units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -1630,8 +1629,8 @@ TEST(operation, bonne_export) {
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
     ASSERT_TRUE(crs != nullptr);
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=unitconvert +xy_in=deg +xy_out=rad "
-              "+step +proj=bonne +lat_1=1 +lon_0=2 +x_0=3 +y_0=4 +ellps=WGS84");
+              "+proj=bonne +lat_1=1 +lon_0=2 +x_0=3 +y_0=4 +ellps=WGS84 "
+              "+units=m +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -3016,12 +3015,6 @@ TEST(operation, webmerc_export) {
     EXPECT_EQ(conv->exportToPROJString(PROJStringFormatter::create().get()),
               "+proj=webmerc +lat_0=0 +lon_0=2 +x_0=3 +y_0=4");
 
-    EXPECT_THROW(
-        conv->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        FormattingException);
-
     EXPECT_EQ(conv->exportToWKT(WKTFormatter::create().get()),
               "CONVERSION[\"Popular Visualisation Pseudo Mercator\",\n"
               "    METHOD[\"Popular Visualisation Pseudo Mercator\",\n"
@@ -3072,20 +3065,17 @@ TEST(operation, webmerc_export) {
         "+x_0=3 +y_0=4 +k=1 +units=m "
         "+nadgrids=@null +wktext +no_defs\"]]");
 
-    EXPECT_EQ(
-        projCRS->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_5)
-                .get()),
-        "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-        "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=webmerc "
-        "+lat_0=0 +lon_0=2 +x_0=3 +y_0=4 +ellps=WGS84");
+    auto op = CoordinateOperationFactory::create()->createOperation(
+        GeographicCRS::EPSG_4326, projCRS);
+    ASSERT_TRUE(op != nullptr);
+    EXPECT_EQ(op->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
+              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=webmerc "
+              "+lat_0=0 +lon_0=2 +x_0=3 +y_0=4 +ellps=WGS84");
 
-    EXPECT_EQ(
-        projCRS->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=2 +x_0=3 "
-        "+y_0=4 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
+    EXPECT_EQ(projCRS->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=2 +x_0=3 "
+              "+y_0=4 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
 }
 
 // ---------------------------------------------------------------------------
@@ -3183,17 +3173,8 @@ TEST(operation, webmerc_import_from_GDAL_wkt1_EPSG_3785_deprecated) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=webmerc "
-              "+lat_0=0 +lon_0=0 +x_0=0 +y_0=0 "
-              "+ellps=WGS84");
-
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 "
-        "+y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
+              "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 "
+              "+y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
 
     auto convGot = crs->derivingConversion();
 
@@ -3257,16 +3238,8 @@ TEST(operation, webmerc_import_from_WKT2_EPSG_3785_deprecated) {
     ASSERT_TRUE(crs != nullptr);
 
     EXPECT_EQ(crs->exportToPROJString(PROJStringFormatter::create().get()),
-              "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-              "+proj=unitconvert +xy_in=deg +xy_out=rad +step +proj=webmerc "
-              "+ellps=WGS84");
-
-    EXPECT_EQ(
-        crs->exportToPROJString(
-            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_4)
-                .get()),
-        "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 "
-        "+y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
+              "+proj=merc +a=6378137 +b=6378137 +lat_ts=0 +lon_0=0 +x_0=0 "
+              "+y_0=0 +k=1 +units=m +nadgrids=@null +wktext +no_defs");
 
     EXPECT_EQ(
         crs->exportToWKT(
@@ -4105,12 +4078,9 @@ TEST(operation, eqearth_export) {
 TEST(operation, laborde_oblique_mercator) {
 
     // Content of EPSG:29701 "Tananarive (Paris) / Laborde Grid"
-    auto projString = "+proj=pipeline +step +proj=axisswap +order=2,1 +step "
-                      "+proj=unitconvert +xy_in=grad +xy_out=rad +step +inv "
-                      "+proj=longlat +ellps=intl +pm=paris +step +proj=labrd "
-                      "+lat_0=-18.9 +lon_0=44.1 +azi=18.9 +k=0.9995 "
-                      "+x_0=400000 +y_0=800000 +ellps=intl +pm=paris +step "
-                      "+proj=axisswap +order=2,1";
+    auto projString = "+proj=labrd +lat_0=-18.9 +lon_0=44.1 +azi=18.9 "
+                      "+k=0.9995 +x_0=400000 +y_0=800000 +ellps=intl +pm=paris "
+                      "+units=m +no_defs";
     auto obj = PROJStringParser().createFromPROJString(projString);
     auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
     ASSERT_TRUE(crs != nullptr);


### PR DESCRIPTION
As discussed in https://github.com/OSGeo/proj.4/issues/1214#issuecomment-452084720,
the introduction of a new PROJ.5 format to export CRS using pipeline/unitconvert/axisswap
as an attempt of improving the PROJ.4 format used by GDAL and other products is
likely a dead-end since it is still lossy in many aspects and can cause confusion
with coodinate operations.

Consequently the PROJ_5 convention will be identical to PROJ_4 for CRS export.

Note: on the import side, I've kept the code that could parse unitconvert and
axisswap when building a CRS definition from a pipeline. It is there as a hidden
feature as it was kind of a tear to remove that code in case it might still be
useful...