### PR TITLE
createOperations(): make it work when transforming between CompoundCRS and Geog3D when the DB has only VertCS to Geog2D

### DIFF
--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -6763,6 +6763,32 @@ TEST(operation, compoundCRS_to_geogCRS_3D_context) {
 
 // ---------------------------------------------------------------------------
 
+TEST(operation, compoundCRS_to_geogCRS_2D_promote_to_3D_context) {
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    // NAD83 + NAVD88 height
+    auto srcObj = createFromUserInput("EPSG:4269+5703",
+                                      authFactory->databaseContext(), false);
+    auto src = nn_dynamic_pointer_cast<CRS>(srcObj);
+    ASSERT_TRUE(src != nullptr);
+    auto nnSrc = NN_NO_CHECK(src);
+    auto dst = authFactory->createCoordinateReferenceSystem("4269"); // NAD83
+    dst = dst->promoteTo3D(std::string(), authFactory->databaseContext());
+    {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            nnSrc, dst, ctxt);
+        ASSERT_GE(list.size(), 8U);
+    }
+    {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            dst, nnSrc, ctxt);
+        ASSERT_GE(list.size(), 8U);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(operation, compoundCRS_from_WKT2_to_geogCRS_3D_context) {
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");


### PR DESCRIPTION
This is needed to fix cases that would not work if using the promoteTo3D()/--3d
functionnality just added per a6e1d72890615b42f54edad9b17acff8e7623844
In some cases, the EPSG database only contains a Geographic 2D CRS (like NAD83),
without a 3D version. Consequently vertical transformations between that
Geographic CRS and a Vertical CRS are only available with a 2D CRS code
(kind of a bug in modelization by the way...). So when promoting the
Geographic 2D CRS to a 3D one, we suddenly cannot find the available
transformations any more. So in such situation, try to fallback to the
2D CRS to restore the capability to find the available transformations.