### PR TITLE
Add transformations for GGM10, Mexican geoid model

### DIFF
--- a/data/sql/customizations.sql
+++ b/data/sql/customizations.sql
@@ -257,6 +257,8 @@ INSERT INTO "geoid_model" SELECT 'GEOID18', auth_name, code FROM grid_transforma
 
 INSERT INTO "geoid_model" SELECT 'OSGM15', auth_name, code FROM grid_transformation WHERE auth_name = 'EPSG' AND grid_name LIKE '%OSGM15%' AND deprecated = 0;
 
+INSERT INTO "geoid_model" SELECT 'GGM10', auth_name, code FROM grid_transformation WHERE auth_name = 'PROJ' AND grid_name LIKE 'GGM10.txt' AND deprecated = 0;
+
 ---- PROJ historic +datum aliases -----
 
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','6326','WGS84','PROJ');

--- a/data/sql/grid_alternatives.sql
+++ b/data/sql/grid_alternatives.sql
@@ -177,6 +177,9 @@ VALUES
 -- jp_gsi - Geospatial Information Authority of Japan
 ('jp_gsi_gsigeo2011.tif','jp_gsi_gsigeo2011.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/jp_gsi_gsigeo2011.tif',1,1,NULL),
 
+-- mx_inegi - Instituto Nacional de Estadística, Geografía e Informática (INEGI) Mexico
+('GGM10.txt','mx_inegi_ggm10.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/mx_inegi_ggm10.tif',1,1,NULL),
+
 -- nc_dittt - Gouvernement de Nouvelle Calédonie - DITTT
 ('Ranc08_Circe.mnt','nc_dittt_Ranc08_Circe.tif',NULL,'GTiff','geoid_like',0,NULL,'https://cdn.proj.org/nc_dittt_Ranc08_Circe.tif',1,1,NULL),
 ('gr3dnc01b.mnt','nc_dittt_gr3dnc01b.tif',NULL,'GTiff','geocentricoffset',0,NULL,'https://cdn.proj.org/nc_dittt_gr3dnc01b.tif',1,1,NULL),

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -230,6 +230,6 @@ INSERT INTO "usage" VALUES(
     'grid_transformation',
     'PROJ',
     'EPSG_6364_TO_EPSG_5703',
-    'EPSG','1160', -- area of use: Mexico - onshore and offshore.
+    'EPSG','3278', -- area of use: Mexico - onshore
     'EPSG','1024'  -- unknown
 );

--- a/data/sql/grid_transformation_custom.sql
+++ b/data/sql/grid_transformation_custom.sql
@@ -211,3 +211,25 @@ INSERT INTO "usage" VALUES(
     'EPSG','1286', -- area of use: Europe - Liechtenstein and Switzerland
     'EPSG','1024'  -- unknown
 );
+
+-- Mexico
+
+INSERT INTO "grid_transformation" VALUES(
+    'PROJ','EPSG_6364_TO_EPSG_5703','Mexico ITRF2008 to NAVD88 height',
+    NULL,
+    'EPSG','9665','Geographic3D to GravityRelatedHeight (gtx)',
+    'EPSG','6364', -- source CRS (Mexico ITRF2008)
+    'EPSG','5703', -- target CRS (NAVD88 height)
+    NULL,
+    'EPSG','8666','Geoid (height correction) model file','GGM10.txt',
+    NULL,NULL,NULL,NULL,NULL,NULL,NULL,0);
+
+INSERT INTO "usage" VALUES(
+    'PROJ',
+    'EPSG_6364_TO_EPSG_5703_USAGE',
+    'grid_transformation',
+    'PROJ',
+    'EPSG_6364_TO_EPSG_5703',
+    'EPSG','1160', -- area of use: Mexico - onshore and offshore.
+    'EPSG','1024'  -- unknown
+);

--- a/data/sql/metadata.sql
+++ b/data/sql/metadata.sql
@@ -18,4 +18,4 @@ INSERT INTO "metadata" VALUES('PROJ.VERSION', '${PROJ_VERSION}');
 
 -- Version of the PROJ-data package with which this database is the most
 -- compatible.
-INSERT INTO "metadata" VALUES('PROJ_DATA.VERSION', '1.7');
+INSERT INTO "metadata" VALUES('PROJ_DATA.VERSION', '1.8');

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -5716,6 +5716,7 @@ TEST_F(CApi, proj_get_geoid_models_from_database) {
     ListFreer freer(list);
     EXPECT_TRUE(findInList(list, "GEOID12B"));
     EXPECT_TRUE(findInList(list, "GEOID18"));
+    EXPECT_TRUE(findInList(list, "GGM10"));
     EXPECT_FALSE(findInList(list, "OSGM15"));
 }
 


### PR DESCRIPTION
 - added entry in `grid_alternatives.sql` for `mx_inegi_ggm10.tif`, included in `PROJ-data`
 - added entry in `grid_transformation_custom.sql` until EPSG is updated. This gives us more time to test the behaviour.
 - added entry in `customizations.sql` in table `geoid_model` for `GGM10`

See related PR OSGeo/PROJ-data#72