### PR TITLE
 Geographic 3D CRS: allow to export to WKT1:ESRI if only the GEOGCS is known (and thus extrapolating a VERTCS) (fixes #2757)

### DIFF
--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -363,6 +363,18 @@ void PrimeMeridian::_exportToWKT(
                     aliasFound = true;
                 }
             }
+            if (!aliasFound && dbContext) {
+                auto authFactory = io::AuthorityFactory::create(
+                    NN_NO_CHECK(dbContext), "ESRI");
+                aliasFound =
+                    authFactory
+                        ->createObjectsFromName(
+                            l_name,
+                            {io::AuthorityFactory::ObjectType::PRIME_MERIDIAN},
+                            false // approximateMatch
+                            )
+                        .size() == 1;
+            }
             if (!aliasFound) {
                 l_name = io::WKTFormatter::morphNameToESRI(l_name);
             }
@@ -820,6 +832,18 @@ void Ellipsoid::_exportToWKT(
                             aliasFound = true;
                         }
                     }
+                    if (!aliasFound && dbContext) {
+                        auto authFactory = io::AuthorityFactory::create(
+                            NN_NO_CHECK(dbContext), "ESRI");
+                        aliasFound = authFactory
+                                         ->createObjectsFromName(
+                                             l_name,
+                                             {io::AuthorityFactory::ObjectType::
+                                                  ELLIPSOID},
+                                             false // approximateMatch
+                                             )
+                                         .size() == 1;
+                    }
                     if (!aliasFound) {
                         l_name = io::WKTFormatter::morphNameToESRI(l_name);
                     }
@@ -1246,6 +1270,18 @@ void GeodeticReferenceFrame::_exportToWKT(
                             aliasFound = true;
                         }
                     }
+                }
+                if (!aliasFound && dbContext) {
+                    auto authFactory = io::AuthorityFactory::create(
+                        NN_NO_CHECK(dbContext), "ESRI");
+                    aliasFound = authFactory
+                                     ->createObjectsFromName(
+                                         l_name,
+                                         {io::AuthorityFactory::ObjectType::
+                                              GEODETIC_REFERENCE_FRAME},
+                                         false // approximateMatch
+                                         )
+                                     .size() == 1;
                 }
                 if (!aliasFound) {
                     l_name = io::WKTFormatter::morphNameToESRI(l_name);
@@ -1984,6 +2020,18 @@ void VerticalReferenceFrame::_exportToWKT(
                     l_name = l_alias;
                     aliasFound = true;
                 }
+            }
+            if (!aliasFound && dbContext) {
+                auto authFactory = io::AuthorityFactory::create(
+                    NN_NO_CHECK(dbContext), "ESRI");
+                aliasFound = authFactory
+                                 ->createObjectsFromName(
+                                     l_name,
+                                     {io::AuthorityFactory::ObjectType::
+                                          VERTICAL_REFERENCE_FRAME},
+                                     false // approximateMatch
+                                     )
+                                 .size() == 1;
             }
             if (!aliasFound) {
                 l_name = io::WKTFormatter::morphNameToESRI(l_name);

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -747,6 +747,46 @@ TEST(crs, EPSG_4268_geogcrs_deprecated_as_WKT1_GDAL) {
 
 // ---------------------------------------------------------------------------
 
+TEST(crs, ESRI_104971_as_WKT1_ESRI_with_database) {
+    auto dbContext = DatabaseContext::create();
+    auto factory = AuthorityFactory::create(dbContext, "ESRI");
+    auto crs = factory->createCoordinateReferenceSystem("104971");
+    WKTFormatterNNPtr f(WKTFormatter::create(
+        WKTFormatter::Convention::WKT1_ESRI, DatabaseContext::create()));
+    // Check that the _(Sphere) suffix is preserved
+    EXPECT_EQ(crs->exportToWKT(f.get()),
+              "GEOGCS[\"Mars_2000_(Sphere)\",DATUM[\"Mars_2000_(Sphere)\","
+              "SPHEROID[\"Mars_2000_(Sphere)\",3396190.0,0.0]],"
+              "PRIMEM[\"Reference_Meridian\",0.0],"
+              "UNIT[\"Degree\",0.0174532925199433]]");
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(crs,
+     implicit_compound_ESRI_104024_plus_115844_as_WKT1_ESRI_with_database) {
+    auto dbContext = DatabaseContext::create();
+    auto obj = createFromUserInput("ESRI:104024+115844", dbContext);
+    auto crs = nn_dynamic_pointer_cast<GeographicCRS>(obj);
+    ASSERT_TRUE(crs != nullptr);
+    EXPECT_EQ(crs->coordinateSystem()->axisList().size(), 3U);
+    WKTFormatterNNPtr f(WKTFormatter::create(
+        WKTFormatter::Convention::WKT1_ESRI, DatabaseContext::create()));
+    // Situation where there is no EPSG official name
+    EXPECT_EQ(crs->exportToWKT(f.get()),
+              "GEOGCS[\"California_SRS_Epoch_2017.50_(NAD83)\","
+              "DATUM[\"California_SRS_Epoch_2017.50_(NAD83)\","
+              "SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],"
+              "PRIMEM[\"Greenwich\",0.0],UNIT[\"Degree\",0.0174532925199433]],"
+              "VERTCS[\"California_SRS_Epoch_2017.50_(NAD83)\","
+              "DATUM[\"California_SRS_Epoch_2017.50_(NAD83)\","
+              "SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],"
+              "PARAMETER[\"Vertical_Shift\",0.0],"
+              "PARAMETER[\"Direction\",1.0],UNIT[\"Meter\",1.0]]");
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(crs, IAU_1000_as_WKT2) {
     auto dbContext = DatabaseContext::create();
     auto factory = AuthorityFactory::create(dbContext, "IAU_2015");
@@ -3873,6 +3913,23 @@ TEST(crs, verticalCRS_down_as_WKT1_ESRI) {
         crs->exportToWKT(
             WKTFormatter::create(WKTFormatter::Convention::WKT1_ESRI).get()),
         wkt);
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(crs, verticalCRS_ESRI_115834_as_WKT1_ESRI_with_database) {
+    auto dbContext = DatabaseContext::create();
+    auto factory = AuthorityFactory::create(dbContext, "ESRI");
+    auto crs = factory->createCoordinateReferenceSystem("115834");
+    WKTFormatterNNPtr f(WKTFormatter::create(
+        WKTFormatter::Convention::WKT1_ESRI, DatabaseContext::create()));
+    // Check that the parentheses in the VERTCS and DATUM names are preserved
+    EXPECT_EQ(crs->exportToWKT(f.get()),
+              "VERTCS[\"NAD83(CSRS)v5\","
+              "DATUM[\"North_American_Datum_of_1983_(CSRS)_version_5\","
+              "SPHEROID[\"GRS_1980\",6378137.0,298.257222101]],"
+              "PARAMETER[\"Vertical_Shift\",0.0],"
+              "PARAMETER[\"Direction\",1.0],UNIT[\"Meter\",1.0]]");
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
The first commit is a real fix
The second one is a bit more arguable. It will not hurt ESRI software apparently, but the CRS will only be partly recgonized