### PR TITLE
CMake: align the VERSION of the library with libtool practices

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,8 +111,13 @@ message(STATUS "Configuring PROJ:")
 ################################################################################
 include(ProjVersion)
 proj_version(MAJOR 8 MINOR 2 PATCH 0)
-set(PROJ_API_VERSION "22")
-set(PROJ_BUILD_VERSION "23.0.1")
+# Use libtool convention to build the CMake's VERSION and SOVERSION
+# See https://github.com/pvanhoof/dir-examples#cmake-in-the-cmake-example
+set(PROJ_LIBTOOL_CURRENT    23)
+set(PROJ_LIBTOOL_REVISION   0)
+set(PROJ_LIBTOOL_AGE        1)
+math(EXPR PROJ_API_VERSION "${PROJ_LIBTOOL_CURRENT} - ${PROJ_LIBTOOL_AGE}")
+set(PROJ_BUILD_VERSION "${PROJ_API_VERSION}.${PROJ_LIBTOOL_AGE}.${PROJ_LIBTOOL_REVISION}")
 
 ################################################################################
 # Build features and variants

--- a/HOWTO-RELEASE
+++ b/HOWTO-RELEASE
@@ -51,8 +51,7 @@ the steps below to determine the next ABI version number:
 Update the following files with the new ABI version number:
 
     - `src/Makefile.am`     Update -version-info
-    - `CMakeLists.txt`:     Update PROJ_BUILD_VERSION (cur:rev:age) and
-                            PROJ_API_VERSION (current-age)
+    - `CMakeLists.txt`:     Update PROJ_LIBTOOL_CURRENT, PROJ_LIBTOOL_REVISON and PROJ_LIBTOOL_AGE
 
 *Commit the changes to master.*
 


### PR DESCRIPTION
Currently (at least as of 8.1.1) we don't have the same .so.x.y.z
numbers for the libtool and cmake builds (the y and z are swapped for
the cmake build). While only the SONAME (the .x part) mostly matters,
it is probably better to stick with the libtool convention to determine
the y and z.
This patch should make it easier by setting explicitly each of the
current, revision, age and computing automatically
x = current - age
y = age
z = revision