### PR TITLE
CMake: revise how we deal with symbol export and static builds

### DIFF
--- a/include/proj/util.hpp
+++ b/include/proj/util.hpp
@@ -50,43 +50,38 @@ namespace proj {}
 //! @cond Doxygen_Suppress
 
 #ifndef PROJ_DLL
-#ifdef PROJ_MSVC_DLL_EXPORT
-#define PROJ_DLL __declspec(dllexport)
-#elif defined(PROJ_MSVC_DLL_IMPORT)
-#define PROJ_DLL __declspec(dllimport)
-#elif defined(__GNUC__)
-#define PROJ_DLL __attribute__((visibility("default")))
-#else
-#define PROJ_DLL
-#endif
+#  if defined(_MSC_VER)
+#    ifdef PROJ_MSVC_DLL_EXPORT
+#      define PROJ_DLL __declspec(dllexport)
+#    else
+#      define PROJ_DLL __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__)
+#    define PROJ_DLL __attribute__ ((visibility("default")))
+#  else
+#    define PROJ_DLL
+#  endif
 #endif
 
 #ifndef PROJ_MSVC_DLL
-
-#ifdef PROJ_MSVC_DLL_EXPORT
-#define PROJ_MSVC_DLL PROJ_DLL
-#define PROJ_GCC_DLL
-#define PROJ_INTERNAL
-#elif defined(PROJ_MSVC_DLL_IMPORT)
-#define PROJ_MSVC_DLL PROJ_DLL
-#define PROJ_GCC_DLL
-#define PROJ_INTERNAL
-#elif defined(__GNUC__)
-#define PROJ_MSVC_DLL
-#define PROJ_GCC_DLL PROJ_DLL
-#if !defined(__MINGW32__)
-#define PROJ_INTERNAL __attribute__((visibility("hidden")))
-#else
-#define PROJ_INTERNAL
-#endif
-#else
-#define PROJ_MSVC_DLL
-#define PROJ_GCC_DLL
-#define PROJ_INTERNAL
-#endif
-
-#define PROJ_FOR_TEST PROJ_DLL
-
+#  if defined(_MSC_VER)
+#    define PROJ_MSVC_DLL PROJ_DLL
+#    define PROJ_GCC_DLL
+#    define PROJ_INTERNAL
+#  elif defined(__GNUC__)
+#    define PROJ_MSVC_DLL
+#    define PROJ_GCC_DLL PROJ_DLL
+#    if !defined(__MINGW32__)
+#      define PROJ_INTERNAL __attribute__((visibility("hidden")))
+#    else
+#      define PROJ_INTERNAL
+#    endif
+#  else
+#    define PROJ_MSVC_DLL
+#    define PROJ_GCC_DLL
+#    define PROJ_INTERNAL
+#  endif
+#  define PROJ_FOR_TEST PROJ_DLL
 #endif
 
 #include "nn.hpp"

--- a/src/bin_cct.cmake
+++ b/src/bin_cct.cmake
@@ -13,7 +13,3 @@ target_compile_options(cct PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS cct
   DESTINATION ${BINDIR})
-
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(cct PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()

--- a/src/bin_cs2cs.cmake
+++ b/src/bin_cs2cs.cmake
@@ -12,7 +12,3 @@ target_compile_options(cs2cs PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS cs2cs
   DESTINATION ${BINDIR})
-
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(cs2cs PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()

--- a/src/bin_geod.cmake
+++ b/src/bin_geod.cmake
@@ -15,10 +15,6 @@ target_compile_options(geod PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS geod
   DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(geod PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()
-
 # invgeod target: symlink or copy of geod executable
 
 if(UNIX)
@@ -47,9 +43,5 @@ else()
 
     install(TARGETS invgeod
       DESTINATION ${BINDIR})
-
-    if(MSVC AND BUILD_SHARED_LIBS)
-      target_compile_definitions(invgeod PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-    endif()
 
 endif()

--- a/src/bin_geodtest.cmake
+++ b/src/bin_geodtest.cmake
@@ -9,7 +9,3 @@ target_compile_options(geodtest PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 # Do not install, instead run as a test
 add_test(NAME geodesic-test COMMAND geodtest)
-
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(geodtest PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()

--- a/src/bin_gie.cmake
+++ b/src/bin_gie.cmake
@@ -15,7 +15,3 @@ if(BUILD_GIE)
   install(TARGETS gie
     DESTINATION ${BINDIR})
 endif()
-
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(gie PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()

--- a/src/bin_proj.cmake
+++ b/src/bin_proj.cmake
@@ -16,10 +16,6 @@ target_compile_options(binproj PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS binproj
   DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(binproj PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()
-
 # invproj target: symlink or copy of proj executable
 
 if(UNIX)
@@ -48,9 +44,5 @@ else()
 
     install(TARGETS invproj
       DESTINATION ${BINDIR})
-
-    if(MSVC AND BUILD_SHARED_LIBS)
-      target_compile_definitions(invproj PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-    endif()
 
 endif()

--- a/src/bin_projinfo.cmake
+++ b/src/bin_projinfo.cmake
@@ -12,10 +12,6 @@ target_compile_options(binprojinfo PRIVATE ${PROJ_CXX_WARN_FLAGS})
 install(TARGETS binprojinfo
   DESTINATION ${BINDIR})
 
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(binprojinfo PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()
-
 if(CURL_ENABLED)
   target_compile_definitions(binprojinfo PRIVATE -DCURL_ENABLED)
 endif()

--- a/src/bin_projsync.cmake
+++ b/src/bin_projsync.cmake
@@ -11,7 +11,3 @@ target_compile_options(bin_projsync PRIVATE ${PROJ_CXX_WARN_FLAGS})
 
 install(TARGETS bin_projsync
   DESTINATION ${BINDIR})
-
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(bin_projsync PRIVATE PROJ_MSVC_DLL_IMPORT=1)
-endif()

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -477,9 +477,12 @@ if(CURL_ENABLED)
       $<$<CXX_COMPILER_ID:MSVC>:normaliz>)
 endif()
 
-if(MSVC AND BUILD_SHARED_LIBS)
-  target_compile_definitions(proj
-    PRIVATE PROJ_MSVC_DLL_EXPORT=1)
+if(BUILD_SHARED_LIBS)
+  if(MSVC)
+    target_compile_definitions(proj PRIVATE PROJ_MSVC_DLL_EXPORT=1)
+  endif()
+else()
+  target_compile_definitions(proj PUBLIC PROJ_DLL=)
 endif()
 
 ##############################################

--- a/src/proj.h
+++ b/src/proj.h
@@ -140,15 +140,17 @@ extern "C" {
 /*! @cond Doxygen_Suppress */
 
 #ifndef PROJ_DLL
-#ifdef PROJ_MSVC_DLL_EXPORT
-#define PROJ_DLL __declspec(dllexport)
-#elif defined(PROJ_MSVC_DLL_IMPORT)
-#define PROJ_DLL __declspec(dllimport)
-#elif defined(__GNUC__)
-#define PROJ_DLL __attribute__ ((visibility("default")))
-#else
-#define PROJ_DLL
-#endif
+#  if defined(_MSC_VER)
+#    ifdef PROJ_MSVC_DLL_EXPORT
+#      define PROJ_DLL __declspec(dllexport)
+#    else
+#      define PROJ_DLL __declspec(dllimport)
+#    endif
+#  elif defined(__GNUC__)
+#    define PROJ_DLL __attribute__ ((visibility("default")))
+#  else
+#    define PROJ_DLL
+#  endif
 #endif
 
 #ifdef PROJ_SUPPRESS_DEPRECATION_MESSAGE

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -51,10 +51,6 @@ endif()  # USE_EXTERNAL_GTEST
 # Build PROJ unit tests
 #
 
-if(MSVC AND BUILD_SHARED_LIBS)
-  add_definitions(-DPROJ_MSVC_DLL_IMPORT=1)
-endif()
-
 include_directories(${PROJ_SOURCE_DIR}/include)
 include_directories(${SQLITE3_INCLUDE_DIR})
 # Add the directory containing proj_config.h


### PR DESCRIPTION
- Remove the explicit PROJ_MSVC_DLL_IMPORT symbol used for importing
  symbols from a MSVC .dll: by default on MSVC, we use
  now __declspec(dllimport), unless PROJ_MSVC_DLL_EXPORT is defined
  by PROJ at build time. This makes it easier for users: they
  don't have to define anything special. This simplifies in particular
  the build of our binaries
- For static builds, export -DPROJ_DLL= as public, so that users
  that import PROJ through CMake mechanism don't have to do it
  manually.
