### PR TITLE
lib_proj.cmake: add a PROJ::proj alias and add BUILD_INTERFACE include directories...

### DIFF
--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -372,6 +372,8 @@ add_library(proj
   ${ALL_LIBPROJ_HEADERS}
   ${PROJ_RESOURCES}
 )
+add_library(PROJ::proj ALIAS proj)
+
 target_compile_options(proj
   PRIVATE $<$<COMPILE_LANGUAGE:C>:${PROJ_C_WARN_FLAGS}>
   PRIVATE $<$<COMPILE_LANGUAGE:CXX>:${PROJ_CXX_WARN_FLAGS}>
@@ -402,6 +404,8 @@ if(ENABLE_IPO)
 endif()
 
 target_include_directories(proj INTERFACE
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}>
+  $<BUILD_INTERFACE:${PROJ_SOURCE_DIR}/include>
   $<INSTALL_INTERFACE:${INCLUDEDIR}>)
 
 if(WIN32)

--- a/travis/install.sh
+++ b/travis/install.sh
@@ -115,10 +115,33 @@ fi
 
 if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
 
-    # cmake build from generated tarball
+    cmake --version
+
+    # Build PROJ as a subproject
+    mkdir proj_as_subproject
+    cd proj_as_subproject
+    mkdir external
+    ln -s $PWD/.. external/PROJ
+
+    echo '#include "proj.h"' > mytest.c
+    echo 'int main() { proj_info(); return 0; }' >> mytest.c
+
+    echo 'cmake_minimum_required(VERSION 3.9)' > CMakeLists.txt
+    echo 'project(mytest)' >> CMakeLists.txt
+    echo 'add_subdirectory(external/PROJ)' >> CMakeLists.txt
+    echo 'add_executable(mytest mytest.c)' >> CMakeLists.txt
+    echo 'target_include_directories(mytest PRIVATE $<TARGET_PROPERTY:PROJ::proj,INTERFACE_INCLUDE_DIRECTORIES>)' >> CMakeLists.txt
+    echo 'target_link_libraries(mytest PRIVATE PROJ::proj)' >> CMakeLists.txt
+
     mkdir build_cmake
     cd build_cmake
-    cmake --version
+    cmake .. -DCMAKE_BUILD_TYPE=Debug
+    VERBOSE=1 make >/dev/null
+    cd ../..
+
+    # Regular build
+    mkdir build_cmake
+    cd build_cmake
     cmake .. -DCMAKE_INSTALL_PREFIX=/tmp/proj_cmake_install
     VERBOSE=1 make >/dev/null
     make install >/dev/null


### PR DESCRIPTION
... so that proj can be used as a subdirectory of a larger project (fixes #2905)
