### PR TITLE
Fixed sql_filelist.cmake relative path issue

### DIFF
--- a/data/sql_filelist.cmake
+++ b/data/sql_filelist.cmake
@@ -1,4 +1,4 @@
-set(SQL_DIR "${CMAKE_CURRENT_SOURCE_DIR}/sql")
+set(SQL_DIR "${CMAKE_CURRENT_LIST_DIR}/sql")
 
 set(SQL_FILES_CONSISTENCY_CHECKS_TRIGGERS
   "${SQL_DIR}/consistency_checks_triggers.sql"


### PR DESCRIPTION
`CMAKE_CURRENT_SOURCE_DIR` is relative to the file that includes `sql_filelist.cmake` not relative to `sql_filelist.cmake` itself. This allows running the module from other portions of a cmake script, for example in a consuming project with FetchContent.
