### PR TITLE
[Backport 9.6] createOperations(): for NAD83(CSRS)[x] to NAD83(CSRS)[y], do not go through NAD83

### DIFF
--- a/test/cli/test_projinfo.yaml
+++ b/test/cli/test_projinfo.yaml
@@ -1934,3 +1934,9 @@ tests:
 - args: -s "Christmas Island Grid 1985" -t "Christmas Island Grid 1985" -o PROJ -q
   out: |
     +proj=noop
+- comment: Test bugfix of https://github.com/OSGeo/PROJ/issues/4464 (NAD83(CSRS) to NAD83(CSRS)v2 should not go through NAD83)
+  args: -s "NAD83(CSRS)" -t "NAD83(CSRS)v2" --spatial-test intersects --summary
+  out: |
+    Candidate operations found: 1
+    unknown id, Ballpark geographic offset from NAD83(CSRS) to NAD83(CSRS)v2, unknown accuracy, Canada - onshore and offshore - Alberta; British Columbia; Manitoba; New Brunswick; Newfoundland and Labrador; Northwest Territories; Nova Scotia; Nunavut; Ontario; Prince Edward Island; Quebec; Saskatchewan; Yukon., has ballpark transformation
+

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -6274,15 +6274,8 @@ TEST(
     {
         auto list = CoordinateOperationFactory::create()->createOperations(
             NN_NO_CHECK(src), NN_NO_CHECK(dst), ctxt);
-        ASSERT_GE(list.size(), 2U);
+        ASSERT_GE(list.size(), 1U);
         EXPECT_EQ(list[0]->nameStr(),
-                  "Inverse of NAD83(CSRS)v6 to CGVD28 height (1) + "
-                  "NAD83(CSRS)v6 to CGVD2013(CGG2013) height (1) "
-                  "using Null geographic offset "
-                  "from NAD83(CSRS)v6 (geog3D) to NAD83(CSRS)v6 (geog2D) + "
-                  "Inverse of NAD83 to NAD83(CSRS)v6 (10) + "
-                  "NAD83 to NAD83(CSRS) (4)");
-        EXPECT_EQ(list[1]->nameStr(),
                   "Inverse of NAD83(CSRS)v6 to CGVD28 height (1) + "
                   "NAD83(CSRS)v6 to CGVD2013(CGG2013) height (1) "
                   "using Ballpark geographic offset "


### PR DESCRIPTION
Backport #4465
 **Authored by:** @rouault