### PR TITLE
opt_parse: avoid potential heap-buffer-overflow when parsing non-ASCII characters (affect cct and gie)

### DIFF
--- a/src/apps/cct.cpp
+++ b/src/apps/cct.cpp
@@ -240,7 +240,7 @@ int main(int argc, char **argv) {
     /* coverity[tainted_data] */
     o = opt_parse(argc, argv, "hvI", "cdozts", longflags, longkeys);
     if (nullptr == o)
-        return 0;
+        return 1;
 
     if (opt_given(o, "h") || argc == 1) {
         printf(usage, o->progname);

--- a/src/apps/gie.cpp
+++ b/src/apps/gie.cpp
@@ -281,7 +281,7 @@ int main(int argc, char **argv) {
     /* coverity[tainted_data] */
     o = opt_parse(argc, argv, "hlvq", "o", longflags, longkeys);
     if (nullptr == o)
-        return 0;
+        return 1;
 
     if (opt_given(o, "h") || argc == 1) {
         printf(usage, o->progname);

--- a/test/cli/run_cli_test.py
+++ b/test/cli/run_cli_test.py
@@ -531,11 +531,11 @@ class Test:
                 return []
             if os.linesep != "\n":  # Handle Windows EOL
                 return (
-                    bytes.decode("utf-8")
+                    bytes.decode("utf-8", errors='ignore')
                     .replace(os.linesep, "\n")
                     .splitlines(keepends=True)
                 )
-            return bytes.decode("utf-8").splitlines(keepends=True)
+            return bytes.decode("utf-8", errors='ignore').splitlines(keepends=True)
 
         stdout_is_text = isinstance(self.stdout, list) or isinstance(self.out, list)
         stdout = bytes2listofstr(proc.stdout) if stdout_is_text else proc.stdout

--- a/test/cli/test_cct.yaml
+++ b/test/cli/test_cct.yaml
@@ -155,3 +155,9 @@ tests:
   args: +proj=noop i_do_not_exist.txt
   stderr: "Cannot open file i_do_not_exist.txt"
   exitcode: 1
+- comment: Test robustness to non-ASCII characters (cf https://github.com/OSGeo/PROJ/issues/4528 case 1)
+  args: "-\uFF56"
+  exitcode: 1
+- comment: Test robustness to non-ASCII characters (cf https://github.com/OSGeo/PROJ/issues/4528 case 2)
+  args: "--\xF3"
+  exitcode: 1


### PR DESCRIPTION
and cct and gie: return error code 1 when argument parsing fails

Fixes #4528