### PR TITLE
createOperations(): fix a case involving 2 CompoundCRS, one with TOWGS84, and the 2 verticalCRS differing by units

### DIFF
--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -6599,6 +6599,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
     }
 
     std::vector<CoordinateOperationNNPtr> verticalTransforms;
+    bool bHasTriedVerticalTransforms = false;
     bool bTryThroughIntermediateGeogCRS = false;
     if (componentsSrc.size() >= 2) {
         const auto vertSrc = componentsSrc[1]->extractVerticalCRS();
@@ -6642,6 +6643,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
                 // If we have a geoid model, force using through it
                 bTryThroughIntermediateGeogCRS = true;
             } else {
+                bHasTriedVerticalTransforms = true;
                 verticalTransforms =
                     createOperations(componentsSrc[1], sourceEpoch,
                                      componentsDst[1], targetEpoch, context);
@@ -6911,6 +6913,12 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToCompound(
 
         if (!res.empty()) {
             return;
+        }
+
+        if (!bHasTriedVerticalTransforms) {
+            verticalTransforms =
+                createOperations(componentsSrc[1], sourceEpoch,
+                                 componentsDst[1], targetEpoch, context);
         }
     }
 


### PR DESCRIPTION
Fixes #4550
