### PR TITLE
[Backport 9.7] proj_clone(): fix insufficient propagation of FORCE_OVER=YES

### DIFF
--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -557,12 +557,14 @@ PJ *proj_clone(PJ_CONTEXT *ctx, const PJ *obj) {
                 newPj->descr = "Set of coordinate operations";
                 newPj->ctx = ctx;
                 newPj->copyStateFrom(*obj);
+                ctx->forceOver = obj->over != 0;
                 const int old_debug_level = ctx->debug_level;
                 ctx->debug_level = PJ_LOG_NONE;
                 for (const auto &altOp : obj->alternativeCoordinateOperations) {
                     newPj->alternativeCoordinateOperations.emplace_back(
                         PJCoordOperation(ctx, altOp));
                 }
+                ctx->forceOver = false;
                 ctx->debug_level = old_debug_level;
             }
             return newPj;
@@ -570,7 +572,9 @@ PJ *proj_clone(PJ_CONTEXT *ctx, const PJ *obj) {
         return nullptr;
     }
     try {
+        ctx->forceOver = obj->over != 0;
         PJ *newPj = pj_obj_create(ctx, NN_NO_CHECK(obj->iso_obj));
+        ctx->forceOver = false;
         if (newPj) {
             newPj->copyStateFrom(*obj);
         }

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -1309,6 +1309,10 @@ TEST(gie, proj_create_crs_to_crs_from_pj_force_over) {
         auto output = proj_trans(P, PJ_FWD, input);
         auto output_over = proj_trans(P, PJ_FWD, input_over);
 
+        auto P_clone = proj_clone(ctx, P);
+        auto output_clone_over = proj_trans(P_clone, PJ_FWD, input_over);
+        proj_destroy(P_clone);
+
         auto input_inv = proj_trans(P, PJ_INV, output);
         auto input_over_inv = proj_trans(P, PJ_INV, output_over);
 
@@ -1319,6 +1323,8 @@ TEST(gie, proj_create_crs_to_crs_from_pj_force_over) {
 
         EXPECT_NEAR(output.xyz.x, 15584728.711058298, 1e-8);
         EXPECT_NEAR(output_over.xyz.x, -24490287.974520184, 1e-8);
+
+        EXPECT_EQ(output_clone_over.xyz.x, output_over.xyz.x);
 
         // The distance from 140 to 180 and -220 to -180 should be pretty much
         // the same.


### PR DESCRIPTION
Backport #4594
 **Authored by:** @rouault