### PR TITLE
CRS identification: fix issue when identifying WKT from older EPSG releases…

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "42ee1775639d3bad348faf598312c8d1")
+set(PROJ_DB_SQL_EXPECTED_MD5 "079de559149b941233e93ba79270eb40")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/alias_name_old_epsg.sql
+++ b/data/sql/alias_name_old_epsg.sql
@@ -1129,10 +1129,16 @@ INSERT INTO "alias_name" VALUES('projected_crs','EPSG','25884','LKS92 / TM Balti
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3447','ETRS89 / Lambert 2005','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','6962','ETRS89 / Albania LCC','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','6870','ETRS89 / Albania TM','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1425','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1431','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1432','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1439','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1447','European Terrestrial Reference System 1989','EPSG_OLD');
 
 -- Changed in EPSG v12.035
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10826','ETRS89 + LAS-2000 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10839','ETRS89 + LAS-2000 height','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1441','European Terrestrial Reference System 1989','EPSG_OLD');
 
 -- Changed in EPSG v12.037
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1132','RDN2008','EPSG_OLD');
@@ -1140,6 +1146,7 @@ INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','6670','IGM95','EPSG_OLD
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3065','ETRF89 IT / UTM zone 33N','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3064','ETRF89 IT / UTM zone 32N','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','9716','ETRF89 IT / UTM zone 34N','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1132','European Terrestrial Reference System 1989','EPSG_OLD');
 
 -- Changed in EPSG v12.038
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3067','EUREF-FIN / UTM zone 35N','EPSG_OLD');
@@ -1152,3 +1159,4 @@ INSERT INTO "alias_name" VALUES('projected_crs','EPSG','5316','ETRS89 / FOTM','E
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','5698','RGF93 / Lambert-93 + NGF-IGN69 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','5699','RGF93 / Lambert-93 + NGF-IGN78 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10659','ETRS89 + EOMA 1980 height','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1031','European Terrestrial Reference System 1989','EPSG_OLD');

--- a/data/sql/commit.sql
+++ b/data/sql/commit.sql
@@ -7,16 +7,6 @@ DELETE FROM alias_name WHERE (table_name, auth_name, code, alt_name) IN
             WHERE source in ('EPSG', 'EPSG_OLD')
             GROUP BY table_name, auth_name, code, alt_name) x WHERE count > 1) AND source = 'EPSG_OLD';
 
--- Remove "conflicting" entries in alias_name, that is entries of EPSG_OLD whose
--- name match an entry of EPSG but with a different code
-
-DELETE FROM alias_name WHERE (table_name, auth_name, code, alt_name, source) IN
-    (SELECT a2.table_name, a2.auth_name, a2.code, a2.alt_name, a2.source
-        FROM alias_name a1 JOIN alias_name a2
-        WHERE a1.table_name = a2.table_name AND a1.code != a2.code AND
-              a1.alt_name = a2.alt_name AND
-              a1.source = 'EPSG' AND a2.source = 'EPSG_OLD');
-
 -- Remove useless entries, i.e. where the official name matches the alias...
 
 DELETE FROM alias_name WHERE (table_name, auth_name, code, alt_name, source) IN

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -3651,6 +3651,40 @@ TEST(crs, projectedCRS_identify_db) {
         EXPECT_EQ(*(res.front().first->identifiers()[0]->codeSpace()), "EPSG");
         EXPECT_EQ(res.front().second, 70);
     }
+
+    {
+        // Identify a CRS after ETRS89 -> ETRS89-PRT [1995] changes
+        auto obj = WKTParser().attachDatabaseContext(dbContext).createFromWKT(
+            "PROJCS[\"ETRS89 / Portugal TM06\","
+            "GEOGCS[\"ETRS89\","
+            "DATUM[\"European Terrestrial Reference System 1989\","
+            "SPHEROID[\"GRS 1980\", 6378137.0, 298.257222101,"
+            "AUTHORITY[\"EPSG\",\"7019\"]],"
+            "AUTHORITY[\"EPSG\",\"6258\"]],"
+            "PRIMEM[\"Greenwich\", 0.0, AUTHORITY[\"EPSG\",\"8901\"]],"
+            "UNIT[\"degree\", 0.017453292519943295],"
+            "AXIS[\"Geodetic latitude\", NORTH],"
+            "AXIS[\"Geodetic longitude\", EAST],"
+            "AUTHORITY[\"EPSG\",\"4258\"]],"
+            "PROJECTION[\"Transverse_Mercator\","
+            "AUTHORITY[\"EPSG\",\"9807\"]],"
+            "PARAMETER[\"central_meridian\", -8.133108333333334],"
+            "PARAMETER[\"latitude_of_origin\", 39.66825833333334],"
+            "PARAMETER[\"scale_factor\", 1.0],"
+            "PARAMETER[\"false_easting\", 0.0],"
+            "PARAMETER[\"false_northing\", 0.0],"
+            "UNIT[\"m\", 1.0],"
+            "AXIS[\"Easting\", EAST],"
+            "AXIS[\"Northing\", NORTH],"
+            "AUTHORITY[\"EPSG\",\"3763\"]]");
+        auto crs = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
+        ASSERT_TRUE(crs != nullptr);
+        auto res = crs->identify(factoryEPSG);
+        ASSERT_GE(res.size(), 1U);
+        EXPECT_EQ(res.front().first->identifiers()[0]->code(), "3763");
+        EXPECT_EQ(*(res.front().first->identifiers()[0]->codeSpace()), "EPSG");
+        EXPECT_EQ(res.front().second, 100);
+    }
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
… with newer ones where the ETRS89-XXX national datums have been added

This helps fixing failure on GDAL autotest/ogr/ogr_shape.py::test_ogr_shape_etrs89_with_zero_TOWGS84 test
