### PR TITLE
docs: add notice about outdated ellipsoid list in usage documentation

### DIFF
--- a/docs/source/usage/ellipsoids.rst
+++ b/docs/source/usage/ellipsoids.rst
@@ -114,7 +114,7 @@ built-in ellipsoid definitions. Default is GRS80 if not given.
 .. note::
 
    The list below is not automatically updated. The command ``proj -le`` lists
-   all available ellipsoids (currently 46), so this table may not include
+   all available ellipsoids, so this table may not include
    all of them. Some values may differ from other sources.
 
 

--- a/docs/source/usage/ellipsoids.rst
+++ b/docs/source/usage/ellipsoids.rst
@@ -111,6 +111,12 @@ Built-in ellipsoid definitions
 
 The ``+ellps=xxx`` parameter provides both size and shape for a number of
 built-in ellipsoid definitions. Default is GRS80 if not given.
+.. note::
+
+   The list below is not automatically updated. The command ``proj -le`` lists
+   all available ellipsoids (currently 46), so this table may not include
+   all of them. Some values may differ from other sources.
+
 
     ============   =================================    ============================
     ellps          Parameters                           Datum name


### PR DESCRIPTION
This PR fixes issue #4253.

I added a notice above the built-in ellipsoid table explaining that the list is no longer updated and may not match the full list shown by `proj-le`. This improves clarity for users and aligns with the maintainers’ suggestion.

This is a documentation-only change.

Checklist:
- [x] Closes #4253
- [ ] Tests added
- [x] Added clear title for release notes
- [ ] Fully documented for new API

