### PR TITLE
Add relavent permissions for image attestation

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -33,6 +33,11 @@ jobs:
             dockerfile: "./docs/docbuild/Dockerfile"
             runner: "ubuntu-24.04"
     runs-on: ${{ matrix.runner }}
+    permissions:
+      contents: read
+      packages: write
+      attestations: write
+      id-token: write
     env:
       # Only push proj-docs package for master
       PUSH_PACKAGES: ${{ github.repository_owner == 'OSGeo' && github.event_name != 'pull_request' && (matrix.container == 'proj' || (matrix.container == 'proj-docs' && github.ref_name == 'master')) }}


### PR DESCRIPTION
Follow up to #4610 

Once merged, there was an error (see here: https://github.com/OSGeo/PROJ/actions/runs/19471499706/job/55719775695 ).  I suspect the error has to do with the respective permissions for attestation not being set.  As things are currently, the permissions are only set when creating the multi-platform manifest.