### PR TITLE
docker image build stage needs 'push' id

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -133,6 +133,7 @@ jobs:
             org.opencontainers.image.created=${{ steps.prep.outputs.BUILD_DATE }}
       - name: Build image
         uses: docker/build-push-action@v6
+        id: push
         if: matrix.container == 'proj'
         with:
           push: ${{ env.PUSH_PACKAGES == 'true' }}
@@ -157,7 +158,7 @@ jobs:
         if: ${{ env.PUSH_PACKAGES == 'true' && matrix.container  == 'proj' }}
         uses: actions/attest-build-provenance@v3
         with:
-          subject-name: ghcr.io/osgeo/${{ matrix.container }}
+          subject-name: ghcr.io/osgeo/proj
           subject-digest: ${{ steps.push.outputs.digest }}
           push-to-registry: ${{ env.PUSH_PACKAGES == 'true' }}
 


### PR DESCRIPTION
Follow up to #4610 and #4612.  Docker attestation was looking for the `digest` output from a previous step, but no id was provided prior to.  Now fixed.