### PR TITLE
Improve build requirements documentation for libtiff and curl (fixes …

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -149,8 +149,8 @@ Build requirements
 - C++17 compiler
 - CMake >= 3.16
 - SQLite3 >= 3.11: headers and library for target architecture, and sqlite3 executable for build architecture
-- libtiff >= 4.0 (optional but recommended to enable reading of grid formats based on GeoTIFF. Only basic TIFF support is required; optional features like WebP or ZStd are not needed.)
-- curl >= 7.29.0 (optional but recommended to support automatic downloading of remote grid files during runtime, allowing PROJ to fetch required transformation data on demand.)
+- libtiff >= 4.0 (optional but recommended to read grid formats based on GeoTIFF. Only basic TIFF support is required; optional features like WebP or ZStd are not needed.)
+- curl >= 7.29.0 (optional but recommended to download required grids at runtime.)
 - JSON for Modern C++ (nlohmann/json) >= 3.7.0; if not found as an external dependency then vendored version 3.9.1 from PROJ source tree is used
 
 .. _test_requirements:

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -149,8 +149,8 @@ Build requirements
 - C++17 compiler
 - CMake >= 3.16
 - SQLite3 >= 3.11: headers and library for target architecture, and sqlite3 executable for build architecture
-- libtiff >= 4.0 (optional but recommended)
-- curl >= 7.29.0 (optional but recommended)
+- libtiff >= 4.0 (optional but recommended to enable reading of grid formats based on GeoTIFF. Only basic TIFF support is required; optional features like WebP or ZStd are not needed.)
+- curl >= 7.29.0 (optional but recommended to support automatic downloading of remote grid files during runtime, allowing PROJ to fetch required transformation data on demand.)
 - JSON for Modern C++ (nlohmann/json) >= 3.7.0; if not found as an external dependency then vendored version 3.9.1 from PROJ source tree is used
 
 .. _test_requirements:

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -1056,3 +1056,5 @@ Zusätze
 integrators
 IntlFeet
 erroring
+WebP
+ZStd


### PR DESCRIPTION
This PR improves the “Build requirements” documentation to explain why libtiff and curl are recommended, including:

libtiff: needed for reading GeoTIFF-based grid formats

curl: required for downloading remote transformation grids at runtime
Fixes #3844.

That’s it.