### PR TITLE
Remove hardcoding of 'ETRS89-NOR [EUREF89]' cases and generalize it to other ETRS89-XXX cases

### DIFF
--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -31,7 +31,7 @@ set(ALL_SQL_IN "${CMAKE_CURRENT_BINARY_DIR}/all.sql.in")
 set(PROJ_DB "${CMAKE_CURRENT_BINARY_DIR}/proj.db")
 include(sql_filelist.cmake)
 
-set(PROJ_DB_SQL_EXPECTED_MD5 "e0922b19b6c4e44a1c490244541c659d")
+set(PROJ_DB_SQL_EXPECTED_MD5 "81e0c15e56d8c84ea95736cecde3dae8")
 
 add_custom_command(
   OUTPUT ${PROJ_DB}

--- a/data/sql/alias_name_old_epsg.sql
+++ b/data/sql/alias_name_old_epsg.sql
@@ -1121,12 +1121,21 @@ INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3885','ETRS-GK31FIN','EP
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','3903','ETRS89-TM35FIN(N,E)/N2000','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','5048','ETRS89-TM35FIN(N,E)','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','3902','ETRS89-TM35FIN(N,E)/N60','EPSG_OLD');
+-- EUREF-FIN
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1391','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10688','ETRS89','EPSG_OLD'); -- ETRS89-FIN [EUREF-FIN] (geocentric)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10689','ETRS89','EPSG_OLD'); -- ETRS89-FIN [EUREF-FIN] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10690','ETRS89','EPSG_OLD'); -- ETRS89-FIN [EUREF-FIN] (2d)
 
 -- Changed in EPSG v12.007
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','25884','LKS92 / TM Baltic93','EPSG_OLD');
 
 -- Changed in EPSG v12.021
+-- ETRS89-NOR [EUREF89]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1407','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10875','ETRS89','EPSG_OLD'); -- ETRS89-NOR [EUREF89] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10874','ETRS89','EPSG_OLD'); -- ETRS89-NOR [EUREF89] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10873','ETRS89','EPSG_OLD'); -- ETRS89-NOR [EUREF89] (geocentric)
 
 -- Changed in EPSG v12.027
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','5973','ETRS89 / UTM zone 33 + NN2000 height','EPSG_OLD');
@@ -1146,50 +1155,100 @@ INSERT INTO "alias_name" VALUES('compound_crs','EPSG','6176','ETRS89 / UTM zone 
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3447','ETRS89 / Lambert 2005','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','6962','ETRS89 / Albania LCC','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','6870','ETRS89 / Albania TM','EPSG_OLD');
+-- OSNet v2009
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1425','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11009','ETRS89','EPSG_OLD'); -- ETRS89-GBR [OSNet v2009] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11008','ETRS89','EPSG_OLD'); -- ETRS89-GBR [OSNet v2009] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11007','ETRS89','EPSG_OLD'); -- ETRS89-GBR [OSNet v2009] (geocentric)
+-- Albanian Geodetic Reference Frame 2010
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1429','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11047','ETRS89','EPSG_OLD'); -- ETRS89-ALB [KRGJSH 2010] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11046','ETRS89','EPSG_OLD'); -- ETRS89-ALB [KRGJSH 2010] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11045','ETRS89','EPSG_OLD'); -- ETRS89-ALB [KRGJSH 2010] (geocentric)
+-- ETRS89-AUT [2002]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1431','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11057','ETRS89','EPSG_OLD'); -- ETRS89-AUT [2002] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11056','ETRS89','EPSG_OLD'); -- ETRS89-AUT [2002] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11055','ETRS89','EPSG_OLD'); -- ETRS89-AUT [2002] (geocentric)
+-- Belgian Reference Frame 2002
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1432','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11063','ETRS89','EPSG_OLD'); -- ETRS89-BEL [BEREF2002] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11062','ETRS89','EPSG_OLD'); -- ETRS89-BEL [BEREF2002] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11061','ETRS89','EPSG_OLD'); -- ETRS89-BEL [BEREF2002] (geocentric)
+-- ETRS89-PRT [1995]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1439','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11108','ETRS89','EPSG_OLD'); -- ETRS89-PRT [1995] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11107','ETRS89','EPSG_OLD'); -- ETRS89-PRT [1995] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11106','ETRS89','EPSG_OLD'); -- ETRS89-PRT [1995] (geocentric)
+-- Belgian Reference Frame 2011
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1447','European Terrestrial Reference System 1989','EPSG_OLD');
+
 
 -- Changed in EPSG v12.035
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10826','ETRS89 + LAS-2000 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10839','ETRS89 + LAS-2000 height','EPSG_OLD');
+-- ETRS89-ESP [REGENTE]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1441','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11134','ETRS89','EPSG_OLD'); -- ETRS89-ESP [REGENTE] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11130','ETRS89','EPSG_OLD'); -- ETRS89-ESP [REGENTE] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11129','ETRS89','EPSG_OLD'); -- ETRS89-ESP [REGENTE] (geocentric)
 
 -- Changed in EPSG v12.037
+-- Rete Dinamica Nazionale 2008
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1132','RDN2008','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1132','European Terrestrial Reference System 1989','EPSG_OLD');
+-- Istituto Geografico Militaire 1995
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','6670','IGM95','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3065','ETRF89 IT / UTM zone 33N','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3064','ETRF89 IT / UTM zone 32N','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','9716','ETRF89 IT / UTM zone 34N','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1132','European Terrestrial Reference System 1989','EPSG_OLD');
 
 -- Changed in EPSG v12.038
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','3067','EUREF-FIN / UTM zone 35N','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10688','ETRS89','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10689','ETRS89','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10690','ETRS89','EPSG_OLD');
 
 -- Changed in EPSG v12.039
 INSERT INTO "alias_name" VALUES('projected_crs','EPSG','5316','ETRS89 / FOTM','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','5698','RGF93 / Lambert-93 + NGF-IGN69 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','5699','RGF93 / Lambert-93 + NGF-IGN78 height','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('compound_crs','EPSG','10659','ETRS89 + EOMA 1980 height','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1031','European Terrestrial Reference System 1989','EPSG_OLD');
+-- ETRS89-FRO [2008]
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1436','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11087','ETRS89','EPSG_OLD'); -- ETRS89-FRO [2008] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11086','ETRS89','EPSG_OLD'); -- ETRS89-FRO [2008] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11085','ETRS89','EPSG_OLD'); -- ETRS89-FRO [2008] (geocentric)
+-- ETRS89-HUN [ETRF2000]
+INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1444','European Terrestrial Reference Frame 2000','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11163','ETRF2000','EPSG_OLD'); -- ETRS89-HUN [ETRF2000] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11162','ETRF2000','EPSG_OLD'); -- ETRS89-HUN [ETRF2000] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11161','ETRF2000','EPSG_OLD'); -- ETRS89-HUN [ETRF2000] (geocentric)
 
 -- Changed in EPSG v12.041
 INSERT INTO "alias_name" VALUES('vertical_datum','EPSG','1297','EVRF2007-PL','EPSG_OLD');
+-- ETRF2000 Poland
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1305','ETRF2000-PL','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','9702','ETRF2000-PL','EPSG_OLD'); -- ETRS89-POL [PL-ETRF2000] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','9701','ETRF2000-PL','EPSG_OLD'); -- ETRS89-POL [PL-ETRF2000] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','9700','ETRF2000-PL','EPSG_OLD'); -- ETRS89-POL [PL-ETRF2000] (geocentric)
 
 -- Changed in EPSG v12.042
+-- Serbian Reference Network 1998
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1034','SREF98','EPSG_OLD');
+-- Serbian Spatial Reference System 2000
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1214','STRS00','EPSG_OLD');
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1214','SRB_ETRS89','EPSG_OLD');
+-- ETRS89/DREF91 Realization 2016
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1353','ETRS89/DREF91/2016','EPSG_OLD');
-INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','10284','ETRS89/DREF91/R16','EPSG_OLD');
+-- ETRS89-IRE [ETRF2000]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','6173','European Terrestrial Reference System 1989','EPSG_OLD');
 
 -- Changed in EPSG v12.043
+-- ETRS89-CZE [2007]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1433','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11070','ETRS89','EPSG_OLD'); -- ETRS89-CZE [2007] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11069','ETRS89','EPSG_OLD'); -- ETRS89-CZE [2007] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11068','ETRS89','EPSG_OLD'); -- ETRS89-CZE [2007] (geocentric)
+-- ETRS89-SVK [SKTRF09]
 INSERT INTO "alias_name" VALUES('geodetic_datum','EPSG','1434','European Terrestrial Reference System 1989','EPSG_OLD');
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11076','ETRS89','EPSG_OLD'); -- ETRS89-SVK [2007] (2d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11075','ETRS89','EPSG_OLD'); -- ETRS89-SVK [2007] (3d)
+INSERT INTO "alias_name" VALUES('geodetic_crs','EPSG','11074','ETRS89','EPSG_OLD'); -- ETRS89-SVK [2007] (geocentric)

--- a/include/proj/datum.hpp
+++ b/include/proj/datum.hpp
@@ -151,6 +151,9 @@ class PROJ_GCC_DLL DatumEnsemble final : public common::ObjectUsage,
     PROJ_INTERNAL void _exportToJSON(io::JSONFormatter *formatter)
         const override; // throw(io::FormattingException)
 
+    PROJ_INTERNAL static std::string
+    ensembleNameToNonEnsembleName(const std::string &s);
+
     PROJ_FOR_TEST DatumNNPtr
     asDatum(const io::DatabaseContextPtr &dbContext) const;
     //! @endcond

--- a/include/proj/io.hpp
+++ b/include/proj/io.hpp
@@ -1335,7 +1335,8 @@ class PROJ_GCC_DLL AuthorityFactory {
                             const std::vector<ObjectType> &allowedObjectTypes =
                                 std::vector<ObjectType>(),
                             bool approximateMatch = true,
-                            size_t limitResultCount = 0) const;
+                            size_t limitResultCount = 0,
+                            bool useAliases = true) const;
 
     PROJ_FOR_TEST std::vector<operation::PointMotionOperationNNPtr>
     getPointMotionOperationsFor(const crs::GeodeticCRSNNPtr &crs,

--- a/src/iso19111/datum.cpp
+++ b/src/iso19111/datum.cpp
@@ -1919,6 +1919,26 @@ DatumEnsemble::positionalAccuracy() const {
 // ---------------------------------------------------------------------------
 
 //! @cond Doxygen_Suppress
+
+/* static */
+std::string DatumEnsemble::ensembleNameToNonEnsembleName(const std::string &s) {
+    if (s == "World Geodetic System 1984 ensemble") {
+        return "World Geodetic System 1984";
+    } else if (s == "European Terrestrial Reference System 1989 ensemble") {
+        return "European Terrestrial Reference System 1989";
+    } else if (s == "Greenland Reference 1996 ensemble") {
+        return "Greenland 1996";
+    }
+    return std::string();
+}
+
+//! @endcond
+
+// ---------------------------------------------------------------------------
+
+// ---------------------------------------------------------------------------
+
+//! @cond Doxygen_Suppress
 DatumNNPtr
 DatumEnsemble::asDatum(const io::DatabaseContextPtr &dbContext) const {
 
@@ -1945,12 +1965,9 @@ DatumEnsemble::asDatum(const io::DatabaseContextPtr &dbContext) const {
     std::string l_name(nameStr());
     if (grf) {
         // Remap to traditional datum names
-        if (l_name == "World Geodetic System 1984 ensemble") {
-            l_name = "World Geodetic System 1984";
-        } else if (l_name ==
-                   "European Terrestrial Reference System 1989 ensemble") {
-            l_name = "European Terrestrial Reference System 1989";
-        }
+        auto oldName = ensembleNameToNonEnsembleName(l_name);
+        if (!oldName.empty())
+            l_name = std::move(oldName);
     }
     auto props =
         util::PropertyMap().set(common::IdentifiedObject::NAME_KEY, l_name);

--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -4932,14 +4932,13 @@ void AuthorityFactory::createGeodeticDatumOrEnsemble(
         const auto &anchor_epoch = row[9];
         const bool deprecated = row[10] == "1";
 
-        std::string massagedName = name;
+        std::string massagedName;
         if (turnEnsembleAsDatum) {
-            if (name == "World Geodetic System 1984 ensemble") {
-                massagedName = "World Geodetic System 1984";
-            } else if (name ==
-                       "European Terrestrial Reference System 1989 ensemble") {
-                massagedName = "European Terrestrial Reference System 1989";
-            }
+            massagedName =
+                datum::DatumEnsemble::ensembleNameToNonEnsembleName(name);
+        }
+        if (massagedName.empty()) {
+            massagedName = name;
         }
         auto props = d->createPropertiesSearchUsages("geodetic_datum", code,
                                                      massagedName, deprecated);

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -2377,18 +2377,20 @@ GeodeticReferenceFrameNNPtr WKTParser::Private::buildGeodeticReferenceFrame(
 
     // Remap GDAL WGS_1984 to EPSG v9 "World Geodetic System 1984" official
     // name.
-    // Also remap EPSG v10 datum ensemble names to non-ensemble EPSG v9
     bool nameSet = false;
-    if (name == "WGS_1984" || name == "World Geodetic System 1984 ensemble") {
+    if (name == "WGS_1984") {
         nameSet = true;
         properties.set(IdentifiedObject::NAME_KEY,
                        GeodeticReferenceFrame::EPSG_6326->nameStr());
-    } else if (name == "European Terrestrial Reference System 1989 ensemble") {
-        nameSet = true;
-        properties.set(IdentifiedObject::NAME_KEY,
-                       "European Terrestrial Reference System 1989");
     }
-
+    // Also remap EPSG v10 datum ensemble names to non-ensemble EPSG v9
+    else if (internal::ends_with(name, " ensemble")) {
+        auto massagedName = DatumEnsemble::ensembleNameToNonEnsembleName(name);
+        if (!massagedName.empty()) {
+            nameSet = true;
+            properties.set(IdentifiedObject::NAME_KEY, massagedName);
+        }
+    }
     // If we got hints this might be a ESRI WKT, then check in the DB to
     // confirm
     std::string officialName;

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -6360,13 +6360,7 @@ void CoordinateOperationFactory::Private::createOperationsCompoundToGeog(
                 const bool srcAndTargetGeogAreSame =
                     componentsSrc[0]->isEquivalentTo(
                         targetCRS->demoteTo2D(std::string(), dbContext).get(),
-                        util::IComparable::Criterion::EQUIVALENT) &&
-                    // Kind of a hack for EPSG:4937 to EPSG:9883 to work
-                    // properly
-                    !((componentsSrc[0]->nameStr() == "ETRS89" &&
-                       targetCRS->nameStr() == "ETRS89-NOR [EUREF89]") ||
-                      (componentsSrc[0]->nameStr() == "ETRS89-NOR [EUREF89]" &&
-                       targetCRS->nameStr() == "ETRS89"));
+                        util::IComparable::Criterion::EQUIVALENT);
 
                 // Lambda to add to the set the name of geodetic datum of the
                 // CRS

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -7910,7 +7910,12 @@ TEST(crs, norway_ntm) {
         auto obj = createFromUserInput(esri_wkt, dbContext, true);
         auto crs_from_esri = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
         ASSERT_TRUE(crs_from_esri != nullptr);
-
+        EXPECT_STREQ(crs_from_esri->nameStr().c_str(),
+                     "ETRS89-NOR [EUREF89] / NTM zone 5");
+        EXPECT_STREQ(crs_from_esri->baseCRS()->nameStr().c_str(),
+                     "ETRS89-NOR [EUREF89]");
+        EXPECT_STREQ(crs_from_esri->baseCRS()->datum()->nameStr().c_str(),
+                     "ETRS89-NOR [EUREF89]");
         auto res = crs_from_esri->identify(factory);
         ASSERT_EQ(res.size(), 1U);
         EXPECT_EQ(res.front().first.get(), crs.get());

--- a/test/unit/test_crs.cpp
+++ b/test/unit/test_crs.cpp
@@ -7992,3 +7992,71 @@ TEST(crs, norway_ntm) {
         EXPECT_EQ(res.front().second, 100);
     }
 }
+// ---------------------------------------------------------------------------
+
+TEST(crs, ETRF2000_PL_CS92) {
+
+    auto dbContext = DatabaseContext::create();
+    auto factory = AuthorityFactory::create(dbContext, "EPSG");
+    // "ETRS89 / PL-1992" (formerly ETRF2000-PL / CS92)
+    auto crs = factory->createCoordinateReferenceSystem("2180");
+
+    auto wkt2_before_epsg_12_041 =
+        "PROJCRS[\"ETRF2000-PL / CS92\",\n"
+        "    BASEGEOGCRS[\"ETRF2000-PL\",\n"
+        "        DATUM[\"ETRF2000 Poland\",\n"
+        "            ELLIPSOID[\"GRS 1980\",6378137,298.257222101,\n"
+        "                LENGTHUNIT[\"metre\",1]]],\n"
+        "        PRIMEM[\"Greenwich\",0,\n"
+        "            ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+        "        ID[\"EPSG\",9702]],\n"
+        "    CONVERSION[\"Poland CS92\",\n"
+        "        METHOD[\"Transverse Mercator\",\n"
+        "            ID[\"EPSG\",9807]],\n"
+        "        PARAMETER[\"Latitude of natural origin\",0,\n"
+        "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "            ID[\"EPSG\",8801]],\n"
+        "        PARAMETER[\"Longitude of natural origin\",19,\n"
+        "            ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "            ID[\"EPSG\",8802]],\n"
+        "        PARAMETER[\"Scale factor at natural origin\",0.9993,\n"
+        "            SCALEUNIT[\"unity\",1],\n"
+        "            ID[\"EPSG\",8805]],\n"
+        "        PARAMETER[\"False easting\",500000,\n"
+        "            LENGTHUNIT[\"metre\",1],\n"
+        "            ID[\"EPSG\",8806]],\n"
+        "        PARAMETER[\"False northing\",-5300000,\n"
+        "            LENGTHUNIT[\"metre\",1],\n"
+        "            ID[\"EPSG\",8807]]],\n"
+        "    CS[Cartesian,2],\n"
+        "        AXIS[\"northing (x)\",north,\n"
+        "            ORDER[1],\n"
+        "            LENGTHUNIT[\"metre\",1]],\n"
+        "        AXIS[\"easting (y)\",east,\n"
+        "            ORDER[2],\n"
+        "            LENGTHUNIT[\"metre\",1]],\n"
+        "    USAGE[\n"
+        "        SCOPE[\"Topographic mapping (medium and small scale).\"],\n"
+        "        AREA[\"Poland - onshore and offshore.\"],\n"
+        "        BBOX[49,14.14,55.93,24.15]],\n"
+        "    ID[\"EPSG\",2180]]";
+
+    {
+        auto obj =
+            createFromUserInput(wkt2_before_epsg_12_041, dbContext, true);
+        auto crs_from_wkt2 = nn_dynamic_pointer_cast<ProjectedCRS>(obj);
+        ASSERT_TRUE(crs_from_wkt2 != nullptr);
+        EXPECT_STREQ(crs_from_wkt2->nameStr().c_str(), "ETRS89 / PL-1992");
+        EXPECT_STREQ(crs_from_wkt2->baseCRS()->nameStr().c_str(), "ETRS89");
+
+        EXPECT_TRUE(crs->isEquivalentTo(crs_from_wkt2.get(),
+                                        IComparable::Criterion::EQUIVALENT));
+        EXPECT_TRUE(crs_from_wkt2->isEquivalentTo(
+            crs.get(), IComparable::Criterion::EQUIVALENT));
+
+        auto res = crs_from_wkt2->identify(factory);
+        ASSERT_EQ(res.size(), 1U);
+        EXPECT_EQ(res.front().first.get(), crs.get());
+        EXPECT_EQ(res.front().second, 100);
+    }
+}


### PR DESCRIPTION
This removes the hacks done in 8682f9f1efa78a6b08a47848edfd4dc25c2f7c7d to have backward compatibility with old Norway CRS based on EPSG:6258 ETRS89 datum, by generalizing them to other similar situations.
