### PR TITLE
fix normalizeForVisualization to skip extent checks for axis-swap ope…

### DIFF
--- a/src/iso19111/operation/concatenatedoperation.cpp
+++ b/src/iso19111/operation/concatenatedoperation.cpp
@@ -176,10 +176,13 @@ ConcatenatedOperationNNPtr ConcatenatedOperation::create(
 
     crs::CRSPtr interpolationCRS;
     bool interpolationCRSValid = true;
+    bool hasBallparkTransformation = false;
     for (size_t i = 0; i < operationsIn.size(); i++) {
         auto l_sourceCRS = operationsIn[i]->sourceCRS();
         auto l_targetCRS = operationsIn[i]->targetCRS();
 
+        hasBallparkTransformation |=
+            operationsIn[i]->hasBallparkTransformation();
         if (interpolationCRSValid) {
             auto subOpInterpCRS = operationsIn[i]->interpolationCRS();
             if (interpolationCRS == nullptr)
@@ -249,6 +252,7 @@ ConcatenatedOperationNNPtr ConcatenatedOperation::create(
         operationsIn);
     op->assignSelf(op);
     op->setProperties(properties);
+    op->setHasBallparkTransformation(hasBallparkTransformation);
     op->setCRSs(l_sourceCRS, l_targetCRS, interpolationCRS);
     op->setAccuracies(accuracies);
 #ifdef DEBUG_CONCATENATED_OPERATION

--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -432,8 +432,13 @@ CoordinateOperation::normalizeForVisualization() const {
                     l_targetCRS->normalizeForVisualization(), nullptr);
         subOps.emplace_back(op);
     }
+    // Use checkExtent=false because axis-swap operations don't change the
+    // geographic validity of the underlying operation - they only reorder
+    // coordinates. This allows normalizeForVisualization() to work on
+    // concatenated operations where sub-operations may have non-overlapping
+    // validity areas (e.g., EPSG:8047).
     return util::nn_static_pointer_cast<CoordinateOperation>(
-        ConcatenatedOperation::createComputeMetadata(subOps, true));
+        ConcatenatedOperation::createComputeMetadata(subOps, false));
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5738,6 +5738,25 @@ TEST(operation, normalizeForVisualization) {
                   "+step +proj=pop +v_3 "
                   "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
     }
+
+    // Test normalizeForVisualization on a concatenated operation with
+    // non-overlapping sub-operation extents (EPSG:8047 = ED50 -> ED87 -> WGS84)
+    // This should work even though EPSG:1147 (ED50->ED87) and EPSG:1146
+    // (ED87->WGS84) have non-overlapping validity areas.
+    {
+        auto op = authFactory->createCoordinateOperation("8047", false);
+        ASSERT_TRUE(op != nullptr);
+        // Verify it's a concatenated operation
+        auto concat = dynamic_cast<const ConcatenatedOperation *>(op.get());
+        ASSERT_TRUE(concat != nullptr);
+        // This should succeed (previously it threw due to extent intersection)
+        auto opNormalized = op->normalizeForVisualization();
+        EXPECT_FALSE(opNormalized->_isEquivalentTo(op.get()));
+        // Verify the normalized operation can produce a PROJ string
+        auto projString = opNormalized->exportToPROJString(
+            PROJStringFormatter::create().get());
+        EXPECT_FALSE(projString.empty());
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5756,6 +5756,14 @@ TEST(operation, normalizeForVisualization) {
         auto projString = opNormalized->exportToPROJString(
             PROJStringFormatter::create().get());
         EXPECT_FALSE(projString.empty());
+        EXPECT_EQ(opNormalized->coordinateOperationAccuracies(),
+                  op->coordinateOperationAccuracies());
+        EXPECT_EQ(opNormalized->remarks(), op->remarks());
+        EXPECT_STREQ(
+            opNormalized->nameStr().c_str(),
+            (op->nameStr() + " (with axis order normalized for visualization)")
+                .c_str());
+        EXPECT_EQ(opNormalized->domains().size(), 1U);
     }
 }
 


### PR DESCRIPTION
This pull request is adding the improvement required in issue #4631.

- ✅ Closes #4631
- ✅ Test added in ``test_operation.cpp``

``proj_normalize_for_visualization()`` currently fails for certain concatenated coordinate operations where the sub-operations have non-overlapping validity areas. This happens because the function internally calls ``ConcatenatedOperation::createComputeMetadata()`` with ``checkExtent = true``, which throws an exception when the validity areas do not intersect.

This PR disables the extent check for the axis-swap wrapper. It is not necessary because the axis-swap operations added by ``normalizeForVisualization()`` have no spatial effect (they only reorder coordinates), so the extent check can be safely skipped.