### PR TITLE
include missing CheckCSourceCompiles

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -363,6 +363,7 @@ endif()
 # Whether we should embed resources
 ################################################################################
 
+include(CheckCSourceCompiles)
 function (is_sharp_embed_available res)
     if (CMAKE_VERSION VERSION_GREATER_EQUAL 3.21 AND
         ((CMAKE_C_COMPILER_ID STREQUAL "GNU" AND CMAKE_C_COMPILER_VERSION VERSION_GREATER_EQUAL 15.0) OR


### PR DESCRIPTION
Minor change to Include `CheckCSourceCompiles` CMake module which provides `check_c_source_compiles`

At the moment it works because some other module pulls it in, but in a spartan environment such as the `emscripten` WASM build, it is missing.

Difficult to test unless a WASM build chain is setup.