### PR TITLE
Docs order operations

### DIFF
--- a/docs/source/operations/transformations/affine.rst
+++ b/docs/source/operations/transformations/affine.rst
@@ -48,58 +48,22 @@ This can be used to implement:
     * :math:`\theta` is the angle about which the axes of the source CRS need to
       be rotated to coincide with the axes of the target CRS, counter-clockwise
       being positive
-      
-Units and Limitations
+
+Usage notes
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
-The :code:`+proj=affine` transformation has specific unit-handling behavior that
-is not obvious from the parameter list. These points are important for correct
-usage:
+The `+proj=affine` operation applies a purely mathematical affine transformation
+on coordinate values. It does **not** perform any unit conversion and is not
+aware of whether coordinates are angular or linear. Users must ensure that the
+values provided to the affine operation are expressed in the appropriate units
+for their intended purpose.
 
-**1. Input and output angular units**
+The affine operation can be used with the `cct` utility or as a step inside a
+PROJ pipeline.
 
-When :code:`+proj=affine` is used on angular coordinates (longitude/latitude):
+Example (using cct):
 
-* **Input angular values are interpreted in radians**
-* **Output angular values are expressed in degrees**
-
-Example (showing the implicit unit conversion):
-
-    $ echo 0 1 | cs2cs +proj=affine +xoff=1
-    57d17'44.806"W  57d17'44.806"N 0.000
-
-The numeric input "1" is interpreted as one radian, and the output is reported
-in degrees. Users should be aware of this implicit unit conversion when applying
-affine steps to geographic coordinate values.
-
-**2. Affine transformation cannot be used directly with the `proj` utility**
-
-Attempting to run:
-
-    proj +proj=affine
-
-will produce the error:
-
-    can't initialize operations that take non-angular input coordinates
-
-This is expected. :code:`+proj=affine` must be used **as a step inside a
-PROJ pipeline**, where its input coordinate type is determined by previous
-pipeline steps.
-
-Example of valid usage inside a pipeline:
-
-    proj pipeline +step +proj=affine +xoff=1
-
-**3. Recommended usage**
-
-The affine transformation is generally intended for:
-
-* Modifying projected coordinates
-* Applying small adjustments inside pipelines
-* Implementing EPSG parametric and similarity transforms
-
-When applied to geographic coordinates, users must explicitly handle/unit-convert
-angles as needed.
+    echo "1 2" | cct +proj=affine +xoff=1
 
 
 Parameters

--- a/docs/source/operations/transformations/affine.rst
+++ b/docs/source/operations/transformations/affine.rst
@@ -48,6 +48,59 @@ This can be used to implement:
     * :math:`\theta` is the angle about which the axes of the source CRS need to
       be rotated to coincide with the axes of the target CRS, counter-clockwise
       being positive
+      
+Units and Limitations
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+The :code:`+proj=affine` transformation has specific unit-handling behavior that
+is not obvious from the parameter list. These points are important for correct
+usage:
+
+**1. Input and output angular units**
+
+When :code:`+proj=affine` is used on angular coordinates (longitude/latitude):
+
+* **Input angular values are interpreted in radians**
+* **Output angular values are expressed in degrees**
+
+Example (showing the implicit unit conversion):
+
+    $ echo 0 1 | cs2cs +proj=affine +xoff=1
+    57d17'44.806"W  57d17'44.806"N 0.000
+
+The numeric input "1" is interpreted as one radian, and the output is reported
+in degrees. Users should be aware of this implicit unit conversion when applying
+affine steps to geographic coordinate values.
+
+**2. Affine transformation cannot be used directly with the `proj` utility**
+
+Attempting to run:
+
+    proj +proj=affine
+
+will produce the error:
+
+    can't initialize operations that take non-angular input coordinates
+
+This is expected. :code:`+proj=affine` must be used **as a step inside a
+PROJ pipeline**, where its input coordinate type is determined by previous
+pipeline steps.
+
+Example of valid usage inside a pipeline:
+
+    proj pipeline +step +proj=affine +xoff=1
+
+**3. Recommended usage**
+
+The affine transformation is generally intended for:
+
+* Modifying projected coordinates
+* Applying small adjustments inside pipelines
+* Implementing EPSG parametric and similarity transforms
+
+When applied to geographic coordinates, users must explicitly handle/unit-convert
+angles as needed.
+
 
 Parameters
 ################################################################################

--- a/docs/source/usage/projections.rst
+++ b/docs/source/usage/projections.rst
@@ -234,6 +234,28 @@ They can be combined in +axis in forms like:
 Order of applications of parameters
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
+The following table summarizes the order in which commonly used parameters
+are applied when specified within the same projection step.
+
++------------+-------------------------------------------------------------+------------------------------+
+| Step Order | Operation                                                   | Parameters                   |
++============+=============================================================+==============================+
+| 1          | Apply prime meridian and central meridian offsets           | ``+pm``, ``+lon_0``           |
++------------+-------------------------------------------------------------+------------------------------+
+| 2          | Normalize longitude range                                   | ``+over``                    |
++------------+-------------------------------------------------------------+------------------------------+
+| 3          | Apply map projection formula and scale factor               | ``+proj``, ``+k_0``, ``+lat_0``|
++------------+-------------------------------------------------------------+------------------------------+
+| 4          | Scale projected coordinates by ellipsoid semimajor axis     | ``+a``                       |
++------------+-------------------------------------------------------------+------------------------------+
+| 5          | Apply false easting and northing                            | ``+x_0``, ``+y_0``           |
++------------+-------------------------------------------------------------+------------------------------+
+| 6          | Apply output horizontal and vertical units                  | ``+units``, ``+to_meter``, ``+vunits`` |
++------------+-------------------------------------------------------------+------------------------------+
+| 7          | Apply axis orientation and order                            | ``+axis``                    |
++------------+-------------------------------------------------------------+------------------------------+
+
+
 In the forward direction (from geodetic to projected coordinates), steps
 are performed in the following order:
 


### PR DESCRIPTION
This PR adds a summary table describing the order in which common projection
parameters are applied within a single projection step.

The table complements the existing detailed explanation in the
"Order of applications of parameters" section and improves clarity
and readability for users.

Fixes #3801

<!-- Feel free to remove check-list items aren't relevant to your change -->

- [x] AI/LLM (Copilot, ChatGPT, Claude or something similar) supported my development of this PR
- [x] Closes #3801
- [ ] Tests added
- [x] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
