### PR TITLE
Generate correct library name in proj.pc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -49,6 +49,7 @@ set(PROJ_common_WARN_FLAGS  # common only to GNU/Clang C/C++
   -Werror=vla
   -Wextra
   -Wformat
+  -Wimplicit-fallthrough
   -Wmissing-declarations
   -Wshadow
   -Wswitch
@@ -59,7 +60,6 @@ if("${CMAKE_C_COMPILER_ID}" STREQUAL "GNU")
     -Wduplicated-cond
     -Wduplicated-branches
     -Wlogical-op
-    -Wimplicit-fallthrough
   )
   set(PROJ_C_WARN_FLAGS ${PROJ_common_WARN_FLAGS}
     -Wmissing-prototypes
@@ -81,7 +81,6 @@ elseif("${CMAKE_C_COMPILER_ID}" MATCHES "Clang")
     -Wdocumentation -Wno-documentation-deprecated-sync
     -Wfloat-conversion
     -Wlogical-op-parentheses
-    -Wimplicit-fallthrough
   )
 
   # Not sure about the minimum version, but clang 12 complains about \file, @cond Doxygen_Suppress, etc.

--- a/proj.pc.in
+++ b/proj.pc.in
@@ -8,7 +8,7 @@ Name: PROJ
 Description: Coordinate transformation software library
 Requires:
 Version: @VERSION@
-Libs: -L${libdir} -lproj
+Libs: -L${libdir} -l@PROJ_OUTPUT_NAME@
 Libs.private: @EXTRA_LIBS@
 Requires.private: @EXTRA_REQUIRES@
 Cflags: -I${includedir}


### PR DESCRIPTION
The library name can be changed
by passing an option to CMake,
so generate the correct proj.pc.

Also throw in a CMake simplification that I noticed while working on this.

- [X] Added clear title that can be used to generate release notes
