### PR TITLE
oss-fuzz: Copy proj.db and additional data files to output directory

### DIFF
--- a/test/fuzzers/build.sh
+++ b/test/fuzzers/build.sh
@@ -88,3 +88,4 @@ echo "[libfuzzer]" > $OUT/proj_crs_to_crs_fuzzer.options
 echo "max_len = 10000" >> $OUT/proj_crs_to_crs_fuzzer.options
 
 cp -r data/* $OUT
+cp -r build/data/* $OUT


### PR DESCRIPTION
When fuzzing, it frequently reports that proj.db is not found:

```
proj_create: Cannot find proj.db
```

The proj.db is generated under build/data, not data/.