### PR TITLE
Add nodejs tests to emscripten compilation

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -32,12 +32,29 @@ jobs:
       - name: Artifacts folder
         run: mkdir -p "$PWD"/wasm_out
 
-      - name: Run docker
-        run: docker run --rm -v "$PWD":/build/proj_src -v "$PWD"/wasm_out:/usr/local/wasm proj-emscripten-builder
+      - name: Run docker build
+        run: |
+          docker run --user $(id -u):$(id -g) --rm \
+            -v "$PWD":/build/proj_src \
+            -v "$PWD"/wasm_out:/build/install \
+            proj-emscripten-builder
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v6
         with:
           name: proj-js-wasm
-          retention-days: 15
+          retention-days: 90
           path: wasm_out/projModule.*
+
+      - name: Copy for tests
+        run: |
+          mkdir -p "$PWD"/out_node
+          cp wasm_out/projModule.* out_node
+          cp scripts/ci/emscripten/proj.ems.tests.js out_node
+
+      - name: Run docker tests
+        run: |
+          docker run --user $(id -u):$(id -g) --rm \
+            -v "$PWD"/out_node:/opt/node/tests \
+            node:24-alpine \
+            node /opt/node/tests/proj.ems.tests.js

--- a/scripts/ci/emscripten/Dockerfile
+++ b/scripts/ci/emscripten/Dockerfile
@@ -12,15 +12,9 @@ RUN apt-get update && \
     # Clean up apt cache to reduce image size
     rm -rf /var/lib/apt/lists/*
 
-# --- Setup Build Directories ---
-# Define standard locations for building and installing
 ENV BUILD_DIR="/build"
-ENV INSTALL_DIR="/usr/local/wasm"
-
-# Create the directories
-RUN mkdir -p ${BUILD_DIR}/proj_src \
-             ${BUILD_DIR}/deps_src \
-             ${INSTALL_DIR}
+RUN mkdir -p ${BUILD_DIR}
+RUN chmod ugo+rwx ${BUILD_DIR}
 
 # Copy the build script into the container
 COPY build_wasm.sh /scripts/build_wasm.sh

--- a/scripts/ci/emscripten/build_wasm.sh
+++ b/scripts/ci/emscripten/build_wasm.sh
@@ -307,6 +307,10 @@ extern "C" {
 const char* get_compilation_date() {
     return "$DDD" ;
 }
+
+int get_ptr_size() {
+    return sizeof(void*);
+}
 }
 EOF
 
@@ -330,7 +334,7 @@ FINAL_LIBS="${INSTALL_DIR}/lib/libproj.a \
             ${WRAPPER_OBJ_FILE}"
 
 # include all exported symbols
-echo -e "_malloc\n_free\n_get_compilation_date" > ${INSTALL_DIR}/exported_symbols.txt
+echo -e "_malloc\n_free\n_get_compilation_date\n_get_ptr_size" > ${INSTALL_DIR}/exported_symbols.txt
 grep "^proj_\|^geod_" ${PROJ_SRC_DIR}/scripts/reference_exported_symbols.txt | grep -v "(" | sed 's/^/_/' >> ${INSTALL_DIR}/exported_symbols.txt
 head ${INSTALL_DIR}/exported_symbols.txt
 

--- a/scripts/ci/emscripten/build_wasm.sh
+++ b/scripts/ci/emscripten/build_wasm.sh
@@ -353,7 +353,7 @@ emcc -v ${FINAL_LIBS} \
     -s EXPORT_NAME="'ProjModuleFactory'" \
     -s FORCE_FILESYSTEM=1 \
     -s ALLOW_MEMORY_GROWTH=1 \
-    -s EXPORTED_RUNTIME_METHODS="[ccall, cwrap, FS, HEAPF64, stringToNewUTF8, UTF8ToString, getValue]" \
+    -s EXPORTED_RUNTIME_METHODS="[ccall, cwrap, FS, HEAP8, HEAP16, HEAP32, HEAPF64, lengthBytesUTF8, stringToUTF8, stringToNewUTF8, UTF8ToString, getValue, setValue]" \
     -s EXPORTED_FUNCTIONS=@${INSTALL_DIR}/exported_symbols.txt \
     ${EM_PTHREADS_FLAGS}
 

--- a/scripts/ci/emscripten/build_wasm.sh
+++ b/scripts/ci/emscripten/build_wasm.sh
@@ -18,12 +18,19 @@ set -e
 # Use environment variables from Dockerfile or runtime.
 PROJ_REPO=${PROJ_REPO:-https://github.com/OSGeo/PROJ.git}
 
-EMSDK_PATH=${EMSDK_PATH:-/emsdk}
+INSTALL_DIR=${INSTALL_DIR:-/build/install}
 BUILD_DIR=${BUILD_DIR:-/build}
-INSTALL_DIR=${INSTALL_DIR:-/usr/local/wasm}
 PROJ_SRC_DIR="${BUILD_DIR}/proj_src"
+PROJ_BUILD_WASM_DIR="${BUILD_DIR}/proj_build_wasm"
 DEPS_SRC_DIR="${BUILD_DIR}/deps_src"
 TEMP_BUILD_DIR="${BUILD_DIR}/temp_build"
+
+# Clean build directories to ensure a fresh build
+rm -rf ${TEMP_BUILD_DIR}
+# We keep DEPS_SRC_DIR to cache downloads
+mkdir -p ${PROJ_SRC_DIR}
+mkdir -p ${DEPS_SRC_DIR}
+mkdir -p ${TEMP_BUILD_DIR}
 
 # Emscripten flags for Pthreads (multithreading support for synchronous emscripten_fetch)
 # and some other.
@@ -65,12 +72,6 @@ if [ "${FORCE_REBUILD}" = "1" ]; then
     echo "!!! FORCE_REBUILD is set. Existing libraries will be ignored and rebuilt. !!!"
     rm -rf "${INSTALL_DIR}"/*
 fi
-
-# Clean build directories to ensure a fresh build
-rm -rf ${TEMP_BUILD_DIR}
-# We keep DEPS_SRC_DIR to cache downloads
-mkdir -p ${TEMP_BUILD_DIR}
-mkdir -p ${DEPS_SRC_DIR}
 
 if [ -f "${PROJ_SRC_DIR}/CMakeLists.txt" ]; then
     echo "Using content from ${PROJ_SRC_DIR} to build PROJ"
@@ -217,8 +218,6 @@ cd ${PROJ_SRC_DIR}
 
 log_step "6. Building and Installing PROJ"
 
-PROJ_BUILD_WASM_DIR="${PROJ_SRC_DIR}/build_wasm"
-
 if [ "${FORCE_REBUILD}" != "1" ] && [ -f "${INSTALL_DIR}/lib/libproj.a" ]; then
     echo "PROJ already built. Skipping."
 else
@@ -232,7 +231,7 @@ else
     cd ${PROJ_BUILD_WASM_DIR}
 
     # Configure PROJ
-    configure_cmake .. \
+    configure_cmake ${PROJ_SRC_DIR} \
         -D BUILD_TESTING=OFF \
         -D BUILD_APPS=OFF \
         -D ENABLE_TIFF=ON \
@@ -330,6 +329,11 @@ FINAL_LIBS="${INSTALL_DIR}/lib/libproj.a \
             ${INSTALL_DIR}/lib/libz.a \
             ${WRAPPER_OBJ_FILE}"
 
+# include all exported symbols
+echo -e "_malloc\n_free\n_get_compilation_date" > ${INSTALL_DIR}/exported_symbols.txt
+grep "^proj_\|^geod_" ${PROJ_SRC_DIR}/scripts/reference_exported_symbols.txt | grep -v "(" | sed 's/^/_/' >> ${INSTALL_DIR}/exported_symbols.txt
+head ${INSTALL_DIR}/exported_symbols.txt
+
 emcc -v ${FINAL_LIBS} \
     -o ${INSTALL_DIR}/projModule.js \
     -O3 \
@@ -346,22 +350,7 @@ emcc -v ${FINAL_LIBS} \
     -s FORCE_FILESYSTEM=1 \
     -s ALLOW_MEMORY_GROWTH=1 \
     -s EXPORTED_RUNTIME_METHODS="[ccall, cwrap, FS, HEAPF64, stringToNewUTF8, UTF8ToString, getValue]" \
-    -s EXPORTED_FUNCTIONS="[
-     _get_compilation_date,
-     _proj_info,
-     _proj_context_errno_string,
-     _proj_context_create,
-     _proj_context_set_enable_network,
-     _proj_create,
-     _proj_create_from_database,
-     _proj_create_crs_to_crs,
-     _proj_create_crs_to_crs_from_pj,
-     _proj_trans,
-     _proj_trans_array,
-     _proj_context_destroy,
-     _proj_destroy,
-     _malloc, _free
-     ]" \
+    -s EXPORTED_FUNCTIONS=@${INSTALL_DIR}/exported_symbols.txt \
     ${EM_PTHREADS_FLAGS}
 
 log_step "BUILD SUCCESSFUL!"

--- a/scripts/ci/emscripten/proj.ems.tests.js
+++ b/scripts/ci/emscripten/proj.ems.tests.js
@@ -157,8 +157,8 @@ const tests = {
             try {
                 // TODO support compound CRS
 
-                // Emscripten (wasm32) pointers are so far 4 bytes
-                const ptrSize = 4;
+                const ptrSize = proj._get_ptr_size();
+                assert.ok(ptrSize == 4 || ptrSize == 8);
                 const doubleSize = 8; // Doubles are 8 bytes
                 const sourceCRS = keep.string(crs);
                 const P_crs = keep.call("_proj_create", ctx, sourceCRS);

--- a/scripts/ci/emscripten/proj.ems.tests.js
+++ b/scripts/ci/emscripten/proj.ems.tests.js
@@ -1,0 +1,193 @@
+const assert = require("node:assert/strict");
+const ProjModuleFactory = require("./projModule.js");
+
+const tests = {
+    test_proj_info : (proj) => {
+        const r = proj.proj_info_ems();
+        const compilation_date =
+            proj.UTF8ToString(proj._get_compilation_date());
+        // Print it for visual inspection
+        console.log(r);
+        console.log(compilation_date);
+        assert(compilation_date.length > 5);
+        assert(r.major >= 9);
+        if (r.major === 9) {
+            assert(r.minor >= 8);
+        }
+        assert(typeof r.minor === "number")
+        assert(typeof r.patch === "number")
+        const rel = `${r.major}.${r.minor}.${r.patch}`;
+        assert(r.release.includes(rel));
+        assert(r.version.includes(rel));
+    },
+
+    test_projinfo : (proj) => {
+        function get_projinfo(args) {
+            let msg = "";
+            const myCallback = (level, message) => { msg += message; };
+            const rc = proj.projinfo_ems(0, args, myCallback);
+            return [ rc, msg ];
+        } {
+            let [rc, msg] = get_projinfo([ "EPSG:32633", "-o", "WKT1:GDAL" ]);
+            assert.equal(rc, 0);
+            assert.ok(msg.includes('PROJCS["WGS 84 / UTM zone 33N"'));
+            assert.ok(msg.includes('AUTHORITY["EPSG","32633"]'));
+        } {let [rc, msg] = get_projinfo([ "EPSG:32633", "-o", "invalid" ]);
+           assert.equal(rc, 1);
+           assert.ok(msg.includes('Unrecognized value '));} {
+            let [rc, msg] = get_projinfo(
+                [ "EPSG:4326", "EPSG:32633", "-o", "proj", "--single-line" ]);
+            assert.equal(rc, 0);
+            assert.ok(msg.includes('Candidate operations'));
+            assert.ok(
+                msg.includes(('+proj=pipeline +step +proj=axisswap +order=2,1 ',
+                              '+step +proj=unitconvert +xy_in=deg +xy_out=rad ',
+                              '+step +proj=utm +zone=33 +ellps=WGS84')));
+        }
+    },
+
+    test_convert : (proj) => {
+        let ctx = proj._proj_context_create();
+        if (ctx === 0) {
+            throw new Error("proj_context_create returned NULL");
+        }
+        const sourceCRS = proj.stringToNewUTF8("EPSG:4326");
+        const targetCRS = proj.stringToNewUTF8("EPSG:32633");
+        const P = proj._proj_create_crs_to_crs(ctx, sourceCRS, targetCRS, 0);
+        if (P === 0) {
+            throw new Error("proj_create_crs_to_crs returned NULL.");
+        }
+        // PJ_COORD is 4 doubles: (x, y, z, t) or (lon, lat, z, t)
+        // We need 4 * 8 = 32 bytes of memory
+        let coordPtr = proj._malloc(32);
+        const coordView = new Float64Array(proj.HEAPF64.buffer, coordPtr, 4);
+        coordView[0] = 52;
+        coordView[1] = 13.5;
+        coordView[2] = 0;
+        coordView[3] = Infinity; // HUGE_VAL
+
+        let res = proj._proj_trans_array(P, 1, 1, coordPtr);
+        if (res != 0) {
+            let msgPtr = proj._proj_context_errno_string(ctx, res);
+            let msg = proj.UTF8ToString(msgPtr);
+            throw new Error(`_proj_trans_array error ${msg}`);
+        }
+        assert(Math.abs(coordView[0] - 397027.0183) < 1e-3);
+        assert(Math.abs(coordView[1] - 5762100.4897) < 1e-3);
+
+        proj._free(coordPtr);
+        proj._proj_destroy(P);
+        proj._free(sourceCRS);
+        proj._free(targetCRS);
+        proj._proj_destroy(ctx);
+    },
+
+    test_axes : (proj) => {
+        let ctx = proj._proj_context_create();
+        if (ctx === 0) {
+            throw new Error("proj_context_create returned NULL");
+        }
+        function get_str(ptr) {
+            const strPtr = proj.getValue(ptr, 'i32'); // It's a pointer (i32)
+            const str = proj.UTF8ToString(strPtr);
+            return str;
+        }
+        function get_axes(crs) {
+            // TODO support compound CRSs with type PJ_TYPE_COMPOUND_CRS = 16;
+
+            // Emscripten (wasm32) pointers are so far 4 bytes
+            const ptrSize = 4;
+            const doubleSize = 8; // Doubles are 8 bytes
+            const sourceCRS = proj.stringToNewUTF8(crs);
+            const P_crs = proj._proj_create(ctx, sourceCRS);
+            const P_cs = proj._proj_crs_get_coordinate_system(ctx, P_crs);
+            const axis_count = proj._proj_cs_get_axis_count(ctx, P_cs);
+            let outNamePtr = proj._malloc(ptrSize);
+            let outAbbrevPtr = proj._malloc(ptrSize);
+            let outDirectionPtr = proj._malloc(ptrSize);
+            let outConvFactorPtr = proj._malloc(doubleSize);
+            let outUnitPtr = proj._malloc(ptrSize);
+            res = {
+                name : [],
+                abbr : [],
+                direction : [],
+                conv_factor : [],
+                unit : []
+            };
+            for (let i = 0; i < axis_count; i++) {
+                const r = proj._proj_cs_get_axis_info(
+                    ctx, P_cs, i, outNamePtr, outAbbrevPtr, outDirectionPtr,
+                    outConvFactorPtr, outUnitPtr, 0, 0);
+                if (r != 1) {
+                    throw new Error("error calling proj_cs_get_axis_info");
+                }
+
+                res.name.push(get_str(outNamePtr));
+                res.abbr.push(get_str(outAbbrevPtr));
+                res.direction.push(get_str(outDirectionPtr));
+                res.conv_factor.push(proj.getValue(outConvFactorPtr, 'double'));
+                res.unit.push(get_str(outUnitPtr));
+            }
+            proj._free(outUnitPtr);
+            proj._free(outConvFactorPtr);
+            proj._free(outDirectionPtr);
+            proj._free(outAbbrevPtr);
+            proj._free(outNamePtr);
+            proj._proj_destroy(P_cs);
+            proj._proj_destroy(P_crs);
+            proj._free(sourceCRS);
+            return res;
+        }
+        const ax4326 = get_axes("EPSG:4326");
+        assert.deepEqual(ax4326, {
+            name : [ 'Geodetic latitude', 'Geodetic longitude' ],
+            abbr : [ 'Lat', 'Lon' ],
+            direction : [ 'north', 'east' ],
+            conv_factor : [ 0.017453292519943295, 0.017453292519943295 ],
+            unit : [ 'degree', 'degree' ]
+        });
+
+        const ax25833 = get_axes("EPSG:25833");
+        assert.deepEqual(ax25833, {
+            name : [ 'Easting', 'Northing' ],
+            abbr : [ 'E', 'N' ],
+            direction : [ 'east', 'north' ],
+            conv_factor : [ 1, 1 ],
+            unit : [ 'metre', 'metre' ]
+        });
+
+        const ax3855 = get_axes("EPSG:3855");
+        assert.deepEqual(ax3855, {
+            name : [ 'Gravity-related height' ],
+            abbr : [ 'H' ],
+            direction : [ 'up' ],
+            conv_factor : [ 1 ],
+            unit : [ 'metre' ]
+        });
+        proj._proj_destroy(ctx);
+    }
+};
+
+if (typeof ProjModuleFactory === 'undefined') {
+    console.error(
+        "'ProjModuleFactory' is not defined. Have you loaded projModule.js.");
+    process.exit(1);
+} else {
+    ProjModuleFactory()
+        .then(module => {
+            proj = module;
+            console.log("Starting tests");
+            let counter = 0;
+            for (let test of Object.keys(tests)) {
+                console.log(`+++++ Running test "${test}"`)
+                tests[test](proj);
+                counter++;
+            };
+            console.log(`Number of tests run: ${counter}`)
+            process.exit(0);
+        })
+        .catch(err => {
+            console.error(`Tests failed: ${err}`);
+            process.exit(1);
+        });
+}


### PR DESCRIPTION
In addition to the compilation with emscripten that produces a wasm and js file, here are some tests in nodejs.
That proves that the wasm can be used, and show some examples (but not going too much in detail).
All the C functions exported in `reference_exported_symbols.txt` are exported here as well. That way the artifacts produced in the github action can be used directly in a web page or node project.

- [ ] ~AI/LLM (Copilot, ChatGPT, Claude or something similar) supported my development of this PR~
- [x] Tests added
- [x] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
