### PR TITLE
Refactor time parsing with thread-safe localtime and leap year fix

### DIFF
--- a/src/param.cpp
+++ b/src/param.cpp
@@ -1,5 +1,6 @@
 /* put parameters in linked list and retrieve */
 
+#include <ctime>
 #include <ctype.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -214,4 +215,41 @@ PROJVALUE pj_param(PJ_CONTEXT *ctx, paralist *pl, const char *opt) {
         break;
     }
     return value;
+}
+
+/* Parse +t_final parameter with support for "now" keyword */
+double pj_parse_t_final(PJ *P) {
+    if (!pj_param(P->ctx, P->params, "tt_final").i) {
+        return 0.0;
+    }
+
+    double t_final = pj_param(P->ctx, P->params, "dt_final").f;
+    if (t_final != 0.0) {
+        return t_final;
+    }
+
+    /* Check if "now" was specified instead of a numeric value */
+    const char *t_final_str = pj_param(P->ctx, P->params, "st_final").s;
+    if (!t_final_str || strcmp("now", t_final_str) != 0) {
+        return 0.0;
+    }
+
+    /* Calculate t_final from current time */
+    time_t now;
+    struct tm date;
+    time(&now);
+#ifdef _WIN32
+    localtime_s(&date, &now);
+#else
+    localtime_r(&now, &date);
+#endif
+
+    const int days_in_year =
+        ((date.tm_year + 1900) % 4 == 0 &&
+         ((date.tm_year + 1900) % 100 != 0 || (date.tm_year + 1900) % 400 == 0))
+            ? 366
+            : 365;
+
+    return 1900.0 + date.tm_year +
+           date.tm_yday / static_cast<double>(days_in_year);
 }

--- a/src/proj_internal.h
+++ b/src/proj_internal.h
@@ -911,6 +911,7 @@ PROJVALUE PROJ_DLL pj_param(PJ_CONTEXT *ctx, paralist *, const char *);
 paralist PROJ_DLL *pj_param_exists(paralist *list, const char *parameter);
 paralist PROJ_DLL *pj_mkparam(const char *);
 paralist *pj_mkparam_ws(const char *str, const char **next_str);
+double pj_parse_t_final(PJ *P);
 
 int PROJ_DLL pj_ell_set(PJ_CONTEXT *ctx, paralist *, double *, double *);
 int pj_datum_set(PJ_CONTEXT *, paralist *, PJ *);

--- a/src/transformations/hgridshift.cpp
+++ b/src/transformations/hgridshift.cpp
@@ -4,7 +4,6 @@
 #include <mutex>
 #include <stddef.h>
 #include <string.h>
-#include <time.h>
 
 #include "grids.hpp"
 #include "proj_internal.h"
@@ -162,22 +161,7 @@ PJ *PJ_TRANSFORMATION(hgridshift, 0) {
         return pj_hgridshift_destructor(P, PROJ_ERR_INVALID_OP_MISSING_ARG);
     }
 
-    /* TODO: Refactor into shared function that can be used  */
-    /*       by both vgridshift and hgridshift               */
-    if (pj_param(P->ctx, P->params, "tt_final").i) {
-        Q->t_final = pj_param(P->ctx, P->params, "dt_final").f;
-        if (Q->t_final == 0) {
-            /* a number wasn't passed to +t_final, let's see if it was "now" */
-            /* and set the time accordingly.                                 */
-            if (!strcmp("now", pj_param(P->ctx, P->params, "st_final").s)) {
-                time_t now;
-                struct tm *date;
-                time(&now);
-                date = localtime(&now);
-                Q->t_final = 1900.0 + date->tm_year + date->tm_yday / 365.0;
-            }
-        }
-    }
+    Q->t_final = pj_parse_t_final(P);
 
     if (pj_param(P->ctx, P->params, "tt_epoch").i)
         Q->t_epoch = pj_param(P->ctx, P->params, "dt_epoch").f;

--- a/src/transformations/vgridshift.cpp
+++ b/src/transformations/vgridshift.cpp
@@ -4,7 +4,6 @@
 #include <mutex>
 #include <stddef.h>
 #include <string.h>
-#include <time.h>
 
 #include "grids.hpp"
 #include "proj_internal.h"
@@ -182,22 +181,7 @@ PJ *PJ_TRANSFORMATION(vgridshift, 0) {
         return pj_vgridshift_destructor(P, PROJ_ERR_INVALID_OP_MISSING_ARG);
     }
 
-    /* TODO: Refactor into shared function that can be used  */
-    /* by both vgridshift and hgridshift                     */
-    if (pj_param(P->ctx, P->params, "tt_final").i) {
-        Q->t_final = pj_param(P->ctx, P->params, "dt_final").f;
-        if (Q->t_final == 0) {
-            /* a number wasn't passed to +t_final, let's see if it was "now" */
-            /* and set the time accordingly.                                 */
-            if (!strcmp("now", pj_param(P->ctx, P->params, "st_final").s)) {
-                time_t now;
-                struct tm *date;
-                time(&now);
-                date = localtime(&now);
-                Q->t_final = 1900.0 + date->tm_year + date->tm_yday / 365.0;
-            }
-        }
-    }
+    Q->t_final = pj_parse_t_final(P);
 
     if (pj_param(P->ctx, P->params, "tt_epoch").i)
         Q->t_epoch = pj_param(P->ctx, P->params, "dt_epoch").f;


### PR DESCRIPTION
replace non-thread-safe `localtime()` with `localtime_r()` (POSIX) / `localtime_s()` (Windows) in hgridshift and vgridshift `+t_final=now` handling. 

also fix leap year calculation: use 366 days for leap years instead of hardcoded 365.


 Closes #4691 


