### PR TITLE
CMake: handle deprecated SQLite::SQLite3 target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,6 +240,10 @@ endif()
 
 find_package(SQLite3 REQUIRED)
 
+if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
+endif()
+
 # Would build and run with older versions, but with horrible performance
 # See https://github.com/OSGeo/PROJ/issues/1718
 if(SQLite3_VERSION VERSION_LESS "3.11")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -241,6 +241,7 @@ endif()
 find_package(SQLite3 REQUIRED)
 
 if(NOT TARGET SQLite3::SQLite3) # CMake < 4.3
+  set_target_properties(SQLite::SQLite3 PROPERTIES IMPORTED_GLOBAL TRUE)
   add_library(SQLite3::SQLite3 ALIAS SQLite::SQLite3)
 endif()
 

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -593,7 +593,7 @@ if(Threads_FOUND AND CMAKE_USE_PTHREADS_INIT)
   target_link_libraries(proj PRIVATE ${CMAKE_THREAD_LIBS_INIT})
 endif()
 
-target_link_libraries(proj PRIVATE SQLite::SQLite3)
+target_link_libraries(proj PRIVATE SQLite3::SQLite3)
 
 if(NLOHMANN_JSON STREQUAL "external")
   target_compile_definitions(proj PRIVATE EXTERNAL_NLOHMANN_JSON)

--- a/test/unit/CMakeLists.txt
+++ b/test/unit/CMakeLists.txt
@@ -179,7 +179,7 @@ set_property(SOURCE ${PROJ_TEST_CPP_API_SOURCES} PROPERTY SKIP_UNITY_BUILD_INCLU
 
 target_link_libraries(proj_test_cpp_api
   PRIVATE GTest::gtest
-  PRIVATE SQLite::SQLite3
+  PRIVATE SQLite3::SQLite3
   PRIVATE ${PROJ_LIBRARIES})
 add_test(NAME proj_test_cpp_api COMMAND proj_test_cpp_api)
 set_property(TEST proj_test_cpp_api
@@ -218,7 +218,7 @@ if(CURL_ENABLED)
 endif()
 target_link_libraries(test_network
   PRIVATE GTest::gtest
-  PRIVATE SQLite::SQLite3
+  PRIVATE SQLite3::SQLite3
   PRIVATE ${PROJ_LIBRARIES})
 if(TIFF_ENABLED)
 add_test(NAME test_network COMMAND test_network)


### PR DESCRIPTION
- CMake >= 4.3 deprecates the `SQLite::SQLite3` target (see [FindSQLite3.html](https://cmake.org/cmake/help/latest/module/FindSQLite3.html))
- using today's CMake 4.3.0-rc2, with Visual Studio, and PROJ master, gives the following warnings:
```
CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at src/lib_proj.cmake:596 (target_link_libraries):
  The library that is being linked to, SQLite::SQLite3, is marked as being
  deprecated by the owner.  The message provided by the developer is:

  The target name SQLite::SQLite3 is deprecated.  Please use SQLite3::SQLite3
  instead.

Call Stack (most recent call first):
  src/CMakeLists.txt:9 (include)
This warning is for project developers.  Use -Wno-dev to suppress it.
```