### PR TITLE
Fix pj_obj_create() grid alternative resolution when old_proj_grid_name is NULL

### DIFF
--- a/include/proj/internal/io_internal.hpp
+++ b/include/proj/internal/io_internal.hpp
@@ -210,6 +210,12 @@ struct PROJ_GCC_DLL projCppContext {
 
     NS_PROJ::io::DatabaseContextNNPtr PROJ_FOR_TEST getDatabaseContext();
 
+    /** Return the database context only if already opened.
+     * Does not attempt to open proj.db. */
+    inline NS_PROJ::io::DatabaseContextPtr getDatabaseContextIfOpen() const {
+        return databaseContext_;
+    }
+
     void closeDb() { databaseContext_ = nullptr; }
 };
 

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -205,8 +205,19 @@ PJ *pj_obj_create(PJ_CONTEXT *ctx, const BaseObjectNNPtr &objIn) {
         }
         if (bTryToExportToProj) {
             try {
+                // Use the database context if already open (e.g. when
+                // coming from proj_create_from_database), so that
+                // substitutePROJAlternativeGridNames() can resolve
+                // grid names via the grid_alternatives table.
+                // Do NOT open the database here — callers such as
+                // proj_create() with a plain pipeline string may run
+                // without proj.db (see commit 63c491eda3).
+                auto dbContext =
+                    ctx->cpp_context
+                        ? ctx->get_cpp_context()->getDatabaseContextIfOpen()
+                        : nullptr;
                 auto formatter = PROJStringFormatter::create(
-                    PROJStringFormatter::Convention::PROJ_5, nullptr);
+                    PROJStringFormatter::Convention::PROJ_5, dbContext);
                 auto projString = coordop->exportToPROJString(formatter.get());
                 const bool defer_grid_opening_backup = ctx->defer_grid_opening;
                 if (!defer_grid_opening_backup &&

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -1694,6 +1694,37 @@ TEST_F(CApi, transformation_from_boundCRS) {
 
 // ---------------------------------------------------------------------------
 
+TEST_F(CApi,
+       proj_create_from_database_grid_alternative_null_old_proj_grid_name) {
+    // EPSG:9484 uses grid "href2008a.bin" whose grid_alternatives entry has
+    // proj_grid_name = "no_kv_href2008a.tif" but old_proj_grid_name IS NULL.
+    // Without the database context in pj_obj_create(),
+    // substitutePROJAlternativeGridNames() cannot resolve the grid name,
+    // leaving the original "href2008a.bin" in the PROJ string. With the fix,
+    // the CDN name "no_kv_href2008a.tif" is used instead.
+    //
+    // Enable network so that pj_obj_create() sets defer_grid_opening=true,
+    // allowing the pipeline to be created even without the grid file on disk.
+    proj_context_set_enable_network(m_ctxt, 1);
+
+    auto op = proj_create_from_database(m_ctxt, "EPSG", "9484",
+                                        PJ_CATEGORY_COORDINATE_OPERATION, false,
+                                        nullptr);
+    ASSERT_NE(op, nullptr);
+    ObjectKeeper keeper(op);
+
+    auto info = proj_pj_info(op);
+    ASSERT_NE(info.definition, nullptr);
+    EXPECT_TRUE(std::string(info.definition).find("no_kv_href2008a.tif") !=
+                std::string::npos)
+        << "Expected CDN grid name 'no_kv_href2008a.tif' in definition, got: "
+        << info.definition;
+
+    proj_context_set_enable_network(m_ctxt, 0);
+}
+
+// ---------------------------------------------------------------------------
+
 TEST_F(CApi, proj_coordoperation_get_grid_used) {
     auto op = proj_create_from_database(m_ctxt, "EPSG", "1312",
                                         PJ_CATEGORY_COORDINATE_OPERATION, true,


### PR DESCRIPTION
The [commit](https://lists.osgeo.org/pipermail/proj/2025-November/011934.html) changed pj_obj_create() to pass nullptr as the database context to PROJStringFormatter::create(), which prevents substitutePROJAlternativeGridNames() from resolving grid names via the grid_alternatives table. The reson for the change was to add support for that plain pipeline strings should work without a proj.db.

Example: proj_create_from_database("EPSG","9484") returns a pipeline with the original grid name ``href2008a.bin`` instead of the CDN name ``no_kv_href2008a.tif``, causing downstream failures.

Fix: Use the database context if it is already open (e.g. when called from proj_create_from_database), but do not open it otherwise — preserving the original intent of 63c491eda3 that plain pipeline strings work without proj.db.


- ✅ Closes #4698
- ✅ Tests added

