### PR TITLE
fix(proj -V): keep easting/northing labels for polar projected CRSs

### DIFF
--- a/src/apps/proj.cpp
+++ b/src/apps/proj.cpp
@@ -4,6 +4,7 @@
 #include "proj_experimental.h"
 #include "proj_internal.h"
 #include "utils.h"
+#include <algorithm>
 #include <ctype.h>
 #include <math.h>
 #include <stdio.h>
@@ -556,10 +557,20 @@ int main(int argc, char **argv) {
                 try {
                     auto crs = dynamic_cast<const NS_PROJ::crs::ProjectedCRS *>(
                         P->iso_obj.get());
-                    auto &dir =
-                        crs->coordinateSystem()->axisList()[0]->direction();
-                    swapAxisCrs = dir == NS_PROJ::cs::AxisDirection::NORTH ||
-                                  dir == NS_PROJ::cs::AxisDirection::SOUTH;
+                    const auto &firstAxis =
+                        crs->coordinateSystem()->axisList()[0];
+                    auto axisName = firstAxis->nameStr();
+                    std::transform(axisName.begin(), axisName.end(),
+                                   axisName.begin(),
+                                   [](unsigned char c) { return tolower(c); });
+                    auto axisAbbrev = firstAxis->abbreviation();
+                    std::transform(axisAbbrev.begin(), axisAbbrev.end(),
+                                   axisAbbrev.begin(),
+                                   [](unsigned char c) { return toupper(c); });
+                    swapAxisCrs = axisName == "northing" ||
+                                  axisName.rfind("northing ", 0) == 0 ||
+                                  axisName.rfind("north", 0) == 0 ||
+                                  axisAbbrev == "N" || axisAbbrev == "Y";
                 } catch (...) {
                 }
                 auto geodetic_crs = proj_get_source_crs(ctx, P);


### PR DESCRIPTION
- [x] AI/LLM (Copilot, ChatGPT, Claude or something similar) supported my development of this PR
- [x] Closes #4573
- [ ] Tests added
- [x] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API

## Summary
- `proj -V` currently decides whether to print `Northing (y)` first by checking whether the first projected axis direction is NORTH/SOUTH.
- Polar CRSs like EPSG:3413 can have first axis **easting** with direction `south` (because of axis meridian orientation), which causes swapped labels.
- This patch determines `swapAxisCrs` from first-axis metadata (`name`/`abbreviation`) instead of raw direction, so easting remains labeled as easting for EPSG:3413/3031-style CRSs.

## Validation
- Could not run local build/tests in this execution environment because `cmake` is not installed (`cmake: command not found`).
- Validation here is code-path review against the issue reproducer and existing axis metadata behavior.

## Related
Closes #4573
