### PR TITLE
Check for NULL from proj_as_proj_string in proj_factors derived CRS handling

### DIFF
--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -257,8 +257,13 @@ PJ_FACTORS proj_factors(PJ *P, PJ_COORD lp) {
             proj_destroy(cs);
 
             // Remove trailing unit conversion and axis swap
-            std::string osProjStr =
+            const char *pszProjStr =
                 proj_as_proj_string(ctx, newOp, PJ_PROJ_5, nullptr);
+            if (!pszProjStr) {
+                proj_destroy(newOp);
+                return factors;
+            }
+            std::string osProjStr = pszProjStr;
             bool resized = false;
             for (const char *suffix :
                  {" +step +proj=unitconvert", " +step +proj=axiswap"}) {
@@ -271,7 +276,9 @@ PJ_FACTORS proj_factors(PJ *P, PJ_COORD lp) {
             if (resized) {
                 proj_destroy(newOp);
                 newOp = proj_create(ctx, osProjStr.c_str());
-                assert(newOp);
+                if (!newOp) {
+                    return factors;
+                }
             }
 
             newOp->fr_meter = cs_unit_conv_factor;

--- a/src/factors.cpp
+++ b/src/factors.cpp
@@ -261,6 +261,8 @@ PJ_FACTORS proj_factors(PJ *P, PJ_COORD lp) {
                 proj_as_proj_string(ctx, newOp, PJ_PROJ_5, nullptr);
             if (!pszProjStr) {
                 proj_destroy(newOp);
+                if (horiz)
+                    proj_destroy(horiz);
                 return factors;
             }
             std::string osProjStr = pszProjStr;

--- a/test/unit/gie_self_tests.cpp
+++ b/test/unit/gie_self_tests.cpp
@@ -798,6 +798,79 @@ TEST(gie, proj_factors) {
         proj_destroy(P);
     }
 
+    // Test with a derived projected CRS that cannot be exported to PROJ string
+    {
+        PJ_COORD c;
+        c.lp.lam = proj_torad(9);
+        c.lp.phi = proj_torad(0);
+
+        const char *wkt =
+            "DERIVEDPROJCRS[\"unknown\",\n"
+            "    BASEPROJCRS[\"unknown\",\n"
+            "        BASEGEOGCRS[\"unknown\",\n"
+            "            DATUM[\"Unknown based on WGS 84 ellipsoid\",\n"
+            "                ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n"
+            "                    LENGTHUNIT[\"metre\",1],\n"
+            "                    ID[\"EPSG\",7030]]],\n"
+            "            PRIMEM[\"Greenwich\",0,\n"
+            "                ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+            "                ID[\"EPSG\",8901]]],\n"
+            "        CONVERSION[\"World Mercator\",\n"
+            "            METHOD[\"Mercator (variant A)\",\n"
+            "                ID[\"EPSG\",9804]],\n"
+            "            PARAMETER[\"Latitude of natural origin\",1,\n"
+            "                ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+            "                ID[\"EPSG\",8801]],\n"
+            "            PARAMETER[\"Longitude of natural origin\",0,\n"
+            "                ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+            "                ID[\"EPSG\",8802]],\n"
+            "            PARAMETER[\"Scale factor at natural origin\",1,\n"
+            "                SCALEUNIT[\"unity\",1],\n"
+            "                ID[\"EPSG\",8805]],\n"
+            "            PARAMETER[\"False easting\",0,\n"
+            "                LENGTHUNIT[\"metre\",1],\n"
+            "                ID[\"EPSG\",8806]],\n"
+            "            PARAMETER[\"False northing\",0,\n"
+            "                LENGTHUNIT[\"metre\",1],\n"
+            "                ID[\"EPSG\",8807]]]],\n"
+            "    DERIVINGCONVERSION[\"Identity\",\n"
+            "        METHOD[\"Affine parametric transformation\",\n"
+            "            ID[\"EPSG\",9624]],\n"
+            "        PARAMETER[\"A0\",0,\n"
+            "            LENGTHUNIT[\"metre\",1],\n"
+            "            ID[\"EPSG\",8623]],\n"
+            "        PARAMETER[\"A1\",1,\n"
+            "            SCALEUNIT[\"coefficient\",1],\n"
+            "            ID[\"EPSG\",8624]],\n"
+            "        PARAMETER[\"A2\",0,\n"
+            "            SCALEUNIT[\"coefficient\",1],\n"
+            "            ID[\"EPSG\",8625]],\n"
+            "        PARAMETER[\"B0\",0,\n"
+            "            LENGTHUNIT[\"metre\",1],\n"
+            "            ID[\"EPSG\",8639]],\n"
+            "        PARAMETER[\"B1\",0,\n"
+            "            SCALEUNIT[\"coefficient\",1],\n"
+            "            ID[\"EPSG\",8640]],\n"
+            "        PARAMETER[\"B2\",1,\n"
+            "            SCALEUNIT[\"coefficient\",1],\n"
+            "            ID[\"EPSG\",8641]]],\n"
+            "    CS[Cartesian,2],\n"
+            "        AXIS[\"easting (X)\",east,\n"
+            "            ORDER[1],\n"
+            "            LENGTHUNIT[\"metre\",1]],\n"
+            "        AXIS[\"northing (Y)\",north,\n"
+            "            ORDER[2],\n"
+            "            LENGTHUNIT[\"metre\",1]]]";
+        P = proj_create(PJ_DEFAULT_CTX, wkt);
+        ASSERT_TRUE(P != nullptr);
+
+        factors = proj_factors(P, c);
+        EXPECT_NE(proj_errno(P), 0);
+        EXPECT_EQ(factors.meridional_scale, 0);
+
+        proj_destroy(P);
+    }
+
     // Same as above but with foot unit
     {
         PJ_COORD c;


### PR DESCRIPTION
### Motivation

- A code path in `proj_factors()` for derived projected CRS constructed a `std::string` from the return value of `proj_as_proj_string()` without checking for `NULL`, which can occur when an object is not exportable or on export error and causes undefined behavior/crash. 
- The change prevents denial-of-service / crash scenarios when processing crafted or non-exportable CRS definitions while preserving existing functionality.

### Description

- Add a `NULL` check for the result of `proj_as_proj_string()` and return safely (after cleaning up) if export fails, avoiding construction of `std::string` from `NULL` in the derived projected CRS branch. (modified `src/factors.cpp`).
- When rebuilding an operation from the trimmed PROJ string, check the result of `proj_create()` and return safely on failure instead of relying only on `assert()` (modified `src/factors.cpp`).
- Add a regression unit test that constructs a derived projected CRS that cannot be exported to a PROJ string and asserts that `proj_factors()` returns an error condition rather than crashing (added test in `test/unit/gie_self_tests.cpp`).

### Testing

- Configured with CMake (`-DCMAKE_BUILD_TYPE=Release`) successfully in this environment. (succeeded)
- Built the project with `cmake --build` successfully and produced binaries. (succeeded)
- Exercised the produced `proj` binary with a simple projection invocation (`./build/bin/proj +proj=merc +ellps=WGS84`) which produced expected numeric output. (succeeded)

- [X] AI/LLM (Codex Security in research preview) supported my development of this PR
- [X] Tests added
- [X] Added clear title that can be used to generate release notes
