### PR TITLE
Chain vertical CRS transformations through intermediate same-datum vertical CRS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,10 @@
 * `createOperationsCompoundToGeog()`: discard 2D-only transformations from interpolation
   3D CRS to target 3D CRS (#4677)
 
+* `createOperations()`: chain vertical CRS transformations through intermediate
+  same-datum vertical CRS when no direct operation exists, avoiding ballpark fallback
+  for CRS pairs differing in axis direction, units, or both
+
 
 ### Bug Fixes
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,11 +45,6 @@
 * `createOperationsCompoundToGeog()`: discard 2D-only transformations from interpolation
   3D CRS to target 3D CRS (#4677)
 
-* `createOperations()`: chain vertical CRS transformations through intermediate
-  same-datum vertical CRS when no direct operation exists, avoiding ballpark fallback
-  for CRS pairs differing in axis direction, units, or both
-
-
 ### Bug Fixes
 
 * CRS identification: fix issue when identifying WKT from older EPSG releases with newer

--- a/NEWS.md
+++ b/NEWS.md
@@ -45,6 +45,7 @@
 * `createOperationsCompoundToGeog()`: discard 2D-only transformations from interpolation
   3D CRS to target 3D CRS (#4677)
 
+
 ### Bug Fixes
 
 * CRS identification: fix issue when identifying WKT from older EPSG releases with newer

--- a/docs/source/operations/operations_computation.rst
+++ b/docs/source/operations/operations_computation.rst
@@ -566,7 +566,15 @@ Overall logic is similar to the above case. There might be direct operations in
 the PROJ database, involving grid transformations or simple offsets. The fallback
 case is to synthesize a ballpark transformation.
 
-This is implemented by the ``createOperationsVertToVert`` method
+When no direct operation is found, a search is made for intermediate vertical CRS
+entries sharing the same datum as the source or target. If a registered operation
+exists between the source (or target) and such an intermediate CRS, it is composed
+with the axis/unit conversion to the actual target (or from the actual source).
+This is implemented by the ``createOperationsVertToVertWithIntermediateVert``
+method and avoids ballpark fallback for CRS pairs that differ only in axis
+direction (height vs depth), units (e.g. metres vs feet), or both.
+
+The direct case is handled by the ``createOperationsVertToVert`` method.
 
 .. code-block:: shell
 

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4605,21 +4605,15 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
                 // first one, which is likely/hopefully the only one.
                 for (const auto &opFirst : opsFirst) {
                     if (hasIdentifiers(opFirst)) {
-                        if (candidateVert->_isEquivalentTo(
-                                targetCRS.get(),
-                                util::IComparable::Criterion::EQUIVALENT)) {
-                            res.emplace_back(opFirst);
-                        } else {
-                            try {
-                                res.emplace_back(
-                                    ConcatenatedOperation::
-                                        createComputeMetadata(
-                                            {opFirst, opsSecond.front()},
-                                            context
-                                                .disallowEmptyIntersection()));
-                            } catch (
-                                const InvalidOperationEmptyIntersection &) {
-                            }
+                        try {
+                            res.emplace_back(
+                                ConcatenatedOperation::
+                                    createComputeMetadata(
+                                        {opFirst, opsSecond.front()},
+                                        context
+                                            .disallowEmptyIntersection()));
+                        } catch (
+                            const InvalidOperationEmptyIntersection &) {
                         }
                     }
                 }
@@ -4648,21 +4642,15 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
             if (!opsFirst.empty()) {
                 for (const auto &opSecond : opsSecond) {
                     if (hasIdentifiers(opSecond)) {
-                        if (candidateVert->_isEquivalentTo(
-                                sourceCRS.get(),
-                                util::IComparable::Criterion::EQUIVALENT)) {
-                            res.emplace_back(opSecond);
-                        } else {
-                            try {
-                                res.emplace_back(
-                                    ConcatenatedOperation::
-                                        createComputeMetadata(
-                                            {opsFirst.front(), opSecond},
-                                            context
-                                                .disallowEmptyIntersection()));
-                            } catch (
-                                const InvalidOperationEmptyIntersection &) {
-                            }
+                        try {
+                            res.emplace_back(
+                                ConcatenatedOperation::
+                                    createComputeMetadata(
+                                        {opsFirst.front(), opSecond},
+                                        context
+                                            .disallowEmptyIntersection()));
+                        } catch (
+                            const InvalidOperationEmptyIntersection &) {
                         }
                     }
                 }

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4632,7 +4632,7 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     // Strategy 2: pivot through candidates sharing the SOURCE's datum.
     // Find vertical CRSs on the same datum as the source, then look for
     // operations from each candidate to the target.
-    {
+    if (res.empty()) {
         auto candidatesSrc = findCandidateVertCRSForDatum(
             authFactory, vertSrc->datumNonNull(dbContext).get());
         for (const auto &candidateVert : candidatesSrc) {

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -560,6 +560,7 @@ struct CoordinateOperationFactory::Private {
         bool inCreateOperationsWithDatumPivotAntiRecursion = false;
         bool inCreateOperationsGeogToVertWithAlternativeGeog = false;
         bool inCreateOperationsGeogToVertWithIntermediateVert = false;
+        bool inCreateOperationsVertToVertWithIntermediateVert = false;
         bool skipHorizontalTransformation = false;
         int nRecLevelCreateOperations = 0;
         std::map<std::pair<io::AuthorityFactory::ObjectType, std::string>,
@@ -647,6 +648,15 @@ struct CoordinateOperationFactory::Private {
     static std::vector<CoordinateOperationNNPtr>
     createOperationsGeogToVertWithAlternativeGeog(
         const crs::CRSNNPtr &sourceCRS, const crs::CRSNNPtr &targetCRS,
+        Context &context);
+
+    static std::vector<CoordinateOperationNNPtr>
+    createOperationsVertToVertWithIntermediateVert(
+        const crs::CRSNNPtr &sourceCRS,
+        const util::optional<common::DataEpoch> &sourceEpoch,
+        const crs::CRSNNPtr &targetCRS,
+        const util::optional<common::DataEpoch> &targetEpoch,
+        const crs::VerticalCRS *vertSrc, const crs::VerticalCRS *vertDst,
         Context &context);
 
     static void createOperationsFromDatabaseWithVertCRS(
@@ -4530,6 +4540,143 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
 
 // ---------------------------------------------------------------------------
 
+// When transforming between two vertical CRS with different datums, check
+// if there are registered operations whose target (or source) is a different
+// vertical CRS sharing the same datum as our target (or source).  If so,
+// chain: source → intermediate + intermediate → target (the latter being a
+// simple unit/axis conversion handled by createOperationsVertToVert).
+//
+// Typical example: Baltic 1977 height (EPSG:5705) → Caspian depth (EPSG:5706).
+// EPSG has an operation 5705 → 5611 (Caspian height).  5611 and 5706 share the
+// same datum but differ only in axis direction.  We compose:
+//   5705 →(EPSG:5438)→ 5611 →(height-to-depth)→ 5706
+std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
+    createOperationsVertToVertWithIntermediateVert(
+        const crs::CRSNNPtr &sourceCRS,
+        const util::optional<common::DataEpoch> &sourceEpoch,
+        const crs::CRSNNPtr &targetCRS,
+        const util::optional<common::DataEpoch> &targetEpoch,
+        const crs::VerticalCRS *vertSrc, const crs::VerticalCRS *vertDst,
+        Private::Context &context) {
+
+    ENTER_FUNCTION();
+
+    std::vector<CoordinateOperationNNPtr> res;
+
+    struct AntiRecursionGuard {
+        Context &context;
+
+        explicit AntiRecursionGuard(Context &contextIn) : context(contextIn) {
+            assert(!context.inCreateOperationsVertToVertWithIntermediateVert);
+            context.inCreateOperationsVertToVertWithIntermediateVert = true;
+        }
+
+        ~AntiRecursionGuard() {
+            context.inCreateOperationsVertToVertWithIntermediateVert = false;
+        }
+    };
+    AntiRecursionGuard guard(context);
+
+    const auto &authFactory = context.context->getAuthorityFactory();
+    if (!authFactory)
+        return res;
+    const auto dbContext = authFactory->databaseContext().as_nullable();
+
+    // Strategy 1: pivot through candidates sharing the TARGET's datum.
+    // Find vertical CRSs on the same datum as the target, then look for
+    // operations from the source to each candidate (using the full
+    // createOperations machinery so multi-step chains are also found).
+    auto candidatesDst = findCandidateVertCRSForDatum(
+        authFactory, vertDst->datumNonNull(dbContext).get());
+    for (const auto &candidateVert : candidatesDst) {
+        if (candidateVert->_isEquivalentTo(
+                targetCRS.get(),
+                util::IComparable::Criterion::EQUIVALENT)) {
+            continue; // Skip the target itself — already tried by the caller.
+        }
+        auto opsFirst = createOperations(sourceCRS, sourceEpoch, candidateVert,
+                                         sourceEpoch, context);
+        if (!opsFirst.empty()) {
+            const auto opsSecond = createOperations(
+                candidateVert, sourceEpoch, targetCRS, targetEpoch, context);
+            if (!opsSecond.empty()) {
+                // The transformation from candidateVert to targetCRS should
+                // be just a unit/axis change typically, so take only the
+                // first one, which is likely/hopefully the only one.
+                for (const auto &opFirst : opsFirst) {
+                    if (hasIdentifiers(opFirst)) {
+                        if (candidateVert->_isEquivalentTo(
+                                targetCRS.get(),
+                                util::IComparable::Criterion::EQUIVALENT)) {
+                            res.emplace_back(opFirst);
+                        } else {
+                            try {
+                                res.emplace_back(
+                                    ConcatenatedOperation::
+                                        createComputeMetadata(
+                                            {opFirst, opsSecond.front()},
+                                            context
+                                                .disallowEmptyIntersection()));
+                            } catch (
+                                const InvalidOperationEmptyIntersection &) {
+                            }
+                        }
+                    }
+                }
+                if (!res.empty())
+                    return res;
+            }
+        }
+    }
+
+    // Strategy 2: pivot through candidates sharing the SOURCE's datum.
+    // Find vertical CRSs on the same datum as the source, then look for
+    // operations from each candidate to the target.
+    auto candidatesSrc = findCandidateVertCRSForDatum(
+        authFactory, vertSrc->datumNonNull(dbContext).get());
+    for (const auto &candidateVert : candidatesSrc) {
+        if (candidateVert->_isEquivalentTo(
+                sourceCRS.get(),
+                util::IComparable::Criterion::EQUIVALENT)) {
+            continue;
+        }
+        auto opsSecond = createOperations(candidateVert, sourceEpoch, targetCRS,
+                                          targetEpoch, context);
+        if (!opsSecond.empty()) {
+            const auto opsFirst = createOperations(
+                sourceCRS, sourceEpoch, candidateVert, sourceEpoch, context);
+            if (!opsFirst.empty()) {
+                for (const auto &opSecond : opsSecond) {
+                    if (hasIdentifiers(opSecond)) {
+                        if (candidateVert->_isEquivalentTo(
+                                sourceCRS.get(),
+                                util::IComparable::Criterion::EQUIVALENT)) {
+                            res.emplace_back(opSecond);
+                        } else {
+                            try {
+                                res.emplace_back(
+                                    ConcatenatedOperation::
+                                        createComputeMetadata(
+                                            {opsFirst.front(), opSecond},
+                                            context
+                                                .disallowEmptyIntersection()));
+                            } catch (
+                                const InvalidOperationEmptyIntersection &) {
+                            }
+                        }
+                    }
+                }
+                if (!res.empty())
+                    return res;
+            }
+        }
+    }
+
+    return res;
+}
+
+// ---------------------------------------------------------------------------
+
 std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     createOperationsGeogToVertWithAlternativeGeog(
         const crs::CRSNNPtr &sourceCRS, // geographic CRS
@@ -4661,6 +4808,19 @@ void CoordinateOperationFactory::Private::
         // do nothing
     } else if (geog3DToVertTryThroughGeog2D(geogDst, vertSrc, sourceCRS)) {
         res = applyInverse(res);
+    }
+
+    // Typically to transform between two vertical CRS with different datums
+    // (e.g. "Baltic 1977 height" to "Caspian depth") by pivoting through
+    // an intermediate vertical CRS sharing the target's (or source's) datum.
+    // This handles the case where a registered CT targets a height CRS but
+    // the user requests the corresponding depth CRS (or vice versa).
+    if (res.empty() &&
+        !context.inCreateOperationsVertToVertWithIntermediateVert && vertSrc &&
+        vertDst) {
+        res = createOperationsVertToVertWithIntermediateVert(
+            sourceCRS, sourceEpoch, targetCRS, targetEpoch, vertSrc, vertDst,
+            context);
     }
 
     // There's no direct transformation from NAVD88 height to WGS84,

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4506,15 +4506,17 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     auto candidatesVert = findCandidateVertCRSForDatum(
         authFactory, vertDst->datumNonNull(dbContext).get());
     for (const auto &candidateVert : candidatesVert) {
+        // Collect all registered source-to-candidate operations, which
+        // may differ in accuracy or area of use, for later ranking.
         auto resTmp = createOperations(sourceCRS, sourceEpoch, candidateVert,
                                        sourceEpoch, context);
         if (!resTmp.empty()) {
+            // The candidate-to-target conversion is expected to be a
+            // trivial unit or axis change, so we only use the first
+            // result (opsSecond.front()).
             const auto opsSecond = createOperations(
                 candidateVert, sourceEpoch, targetCRS, targetEpoch, context);
             if (!opsSecond.empty()) {
-                // The transformation from candidateVert to targetCRS should
-                // be just a unit change typically, so take only the first one,
-                // which is likely/hopefully the only one.
                 for (const auto &opFirst : resTmp) {
                     if (hasIdentifiers(opFirst)) {
                         if (candidateVert->_isEquivalentTo(
@@ -4593,15 +4595,17 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
                 targetCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
             continue; // Skip the target itself (already tried by the caller)
         }
+        // Collect all registered source-to-candidate operations, which
+        // may differ in accuracy or area of use, for later ranking.
         auto opsFirst = createOperations(sourceCRS, sourceEpoch, candidateVert,
                                          sourceEpoch, context);
         if (!opsFirst.empty()) {
+            // The candidate-to-target conversion is expected to be a
+            // trivial unit or axis change, so we only use the first
+            // result (opsSecond.front()).
             const auto opsSecond = createOperations(
                 candidateVert, sourceEpoch, targetCRS, targetEpoch, context);
             if (!opsSecond.empty()) {
-                // The transformation from candidateVert to targetCRS should
-                // be just a unit/axis change typically, so take only the
-                // first one, which is likely/hopefully the only one.
                 for (const auto &opFirst : opsFirst) {
                     if (hasIdentifiers(opFirst)) {
                         try {

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4590,8 +4590,7 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
         authFactory, vertDst->datumNonNull(dbContext).get());
     for (const auto &candidateVert : candidatesDst) {
         if (candidateVert->_isEquivalentTo(
-                targetCRS.get(),
-                util::IComparable::Criterion::EQUIVALENT)) {
+                targetCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
             continue; // Skip the target itself — already tried by the caller.
         }
         auto opsFirst = createOperations(sourceCRS, sourceEpoch, candidateVert,
@@ -4607,13 +4606,10 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
                     if (hasIdentifiers(opFirst)) {
                         try {
                             res.emplace_back(
-                                ConcatenatedOperation::
-                                    createComputeMetadata(
-                                        {opFirst, opsSecond.front()},
-                                        context
-                                            .disallowEmptyIntersection()));
-                        } catch (
-                            const InvalidOperationEmptyIntersection &) {
+                                ConcatenatedOperation::createComputeMetadata(
+                                    {opFirst, opsSecond.front()},
+                                    context.disallowEmptyIntersection()));
+                        } catch (const InvalidOperationEmptyIntersection &) {
                         }
                     }
                 }
@@ -4630,8 +4626,7 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
         authFactory, vertSrc->datumNonNull(dbContext).get());
     for (const auto &candidateVert : candidatesSrc) {
         if (candidateVert->_isEquivalentTo(
-                sourceCRS.get(),
-                util::IComparable::Criterion::EQUIVALENT)) {
+                sourceCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
             continue;
         }
         auto opsSecond = createOperations(candidateVert, sourceEpoch, targetCRS,
@@ -4644,13 +4639,10 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
                     if (hasIdentifiers(opSecond)) {
                         try {
                             res.emplace_back(
-                                ConcatenatedOperation::
-                                    createComputeMetadata(
-                                        {opsFirst.front(), opSecond},
-                                        context
-                                            .disallowEmptyIntersection()));
-                        } catch (
-                            const InvalidOperationEmptyIntersection &) {
+                                ConcatenatedOperation::createComputeMetadata(
+                                    {opsFirst.front(), opSecond},
+                                    context.disallowEmptyIntersection()));
+                        } catch (const InvalidOperationEmptyIntersection &) {
                         }
                     }
                 }

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4584,41 +4584,48 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
         return res;
     const auto dbContext = authFactory->databaseContext().as_nullable();
 
+    // Try both pivot strategies and collect all candidates.  The caller's
+    // filterAndSort will rank them (by accuracy, area of use, etc.)
+
     // Strategy 1: pivot through candidates sharing the TARGET's datum.
-    // Find vertical CRSs on the same datum as the target, then look for
-    // operations from the source to each candidate (using the full
-    // createOperations machinery so multi-step chains are also found).
-    auto candidatesDst = findCandidateVertCRSForDatum(
-        authFactory, vertDst->datumNonNull(dbContext).get());
-    for (const auto &candidateVert : candidatesDst) {
-        if (candidateVert->_isEquivalentTo(
-                targetCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
-            continue; // Skip the target itself (already tried by the caller)
-        }
-        // Collect all registered source-to-candidate operations, which
-        // may differ in accuracy or area of use, for later ranking.
-        auto opsFirst = createOperations(sourceCRS, sourceEpoch, candidateVert,
-                                         sourceEpoch, context);
-        if (!opsFirst.empty()) {
-            // The candidate-to-target conversion is expected to be a
-            // trivial unit or axis change, so we only use the first
-            // result (opsSecond.front()).
-            const auto opsSecond = createOperations(
-                candidateVert, sourceEpoch, targetCRS, targetEpoch, context);
-            if (!opsSecond.empty()) {
-                for (const auto &opFirst : opsFirst) {
-                    if (hasIdentifiers(opFirst)) {
-                        try {
-                            res.emplace_back(
-                                ConcatenatedOperation::createComputeMetadata(
-                                    {opFirst, opsSecond.front()},
-                                    context.disallowEmptyIntersection()));
-                        } catch (const InvalidOperationEmptyIntersection &) {
+    // source -> candidate (registered CT) -> target (trivial axis/unit change)
+    {
+        auto candidatesDst = findCandidateVertCRSForDatum(
+            authFactory, vertDst->datumNonNull(dbContext).get());
+        for (const auto &candidateVert : candidatesDst) {
+            if (candidateVert->_isEquivalentTo(
+                    targetCRS.get(),
+                    util::IComparable::Criterion::EQUIVALENT)) {
+                continue;
+            }
+            // Collect all registered source-to-candidate operations, which
+            // may differ in accuracy or area of use, for later ranking.
+            auto opsFirst = createOperations(sourceCRS, sourceEpoch,
+                                             candidateVert, sourceEpoch,
+                                             context);
+            if (!opsFirst.empty()) {
+                // The candidate-to-target conversion is expected to be a
+                // trivial unit or axis change, so we only use the first
+                // result (opsSecond.front()).
+                const auto opsSecond = createOperations(
+                    candidateVert, sourceEpoch, targetCRS, targetEpoch,
+                    context);
+                if (!opsSecond.empty()) {
+                    for (const auto &opFirst : opsFirst) {
+                        if (hasIdentifiers(opFirst)) {
+                            try {
+                                res.emplace_back(
+                                    ConcatenatedOperation::
+                                        createComputeMetadata(
+                                            {opFirst, opsSecond.front()},
+                                            context
+                                                .disallowEmptyIntersection()));
+                            } catch (
+                                const InvalidOperationEmptyIntersection &) {
+                            }
                         }
                     }
                 }
-                if (!res.empty())
-                    return res;
             }
         }
     }
@@ -4626,32 +4633,37 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     // Strategy 2: pivot through candidates sharing the SOURCE's datum.
     // Find vertical CRSs on the same datum as the source, then look for
     // operations from each candidate to the target.
-    auto candidatesSrc = findCandidateVertCRSForDatum(
-        authFactory, vertSrc->datumNonNull(dbContext).get());
-    for (const auto &candidateVert : candidatesSrc) {
-        if (candidateVert->_isEquivalentTo(
-                sourceCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
-            continue;
-        }
-        auto opsSecond = createOperations(candidateVert, sourceEpoch, targetCRS,
-                                          targetEpoch, context);
-        if (!opsSecond.empty()) {
-            const auto opsFirst = createOperations(
-                sourceCRS, sourceEpoch, candidateVert, sourceEpoch, context);
-            if (!opsFirst.empty()) {
-                for (const auto &opSecond : opsSecond) {
-                    if (hasIdentifiers(opSecond)) {
-                        try {
-                            res.emplace_back(
-                                ConcatenatedOperation::createComputeMetadata(
-                                    {opsFirst.front(), opSecond},
-                                    context.disallowEmptyIntersection()));
-                        } catch (const InvalidOperationEmptyIntersection &) {
+    {
+        auto candidatesSrc = findCandidateVertCRSForDatum(
+            authFactory, vertSrc->datumNonNull(dbContext).get());
+        for (const auto &candidateVert : candidatesSrc) {
+            if (candidateVert->_isEquivalentTo(
+                    sourceCRS.get(),
+                    util::IComparable::Criterion::EQUIVALENT)) {
+                continue;
+            }
+            auto opsSecond = createOperations(candidateVert, sourceEpoch,
+                                              targetCRS, targetEpoch, context);
+            if (!opsSecond.empty()) {
+                const auto opsFirst = createOperations(
+                    sourceCRS, sourceEpoch, candidateVert, sourceEpoch,
+                    context);
+                if (!opsFirst.empty()) {
+                    for (const auto &opSecond : opsSecond) {
+                        if (hasIdentifiers(opSecond)) {
+                            try {
+                                res.emplace_back(
+                                    ConcatenatedOperation::
+                                        createComputeMetadata(
+                                            {opsFirst.front(), opSecond},
+                                            context
+                                                .disallowEmptyIntersection()));
+                            } catch (
+                                const InvalidOperationEmptyIntersection &) {
+                            }
                         }
                     }
                 }
-                if (!res.empty())
-                    return res;
             }
         }
     }

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4543,13 +4543,13 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
 // When transforming between two vertical CRS with different datums, check
 // if there are registered operations whose target (or source) is a different
 // vertical CRS sharing the same datum as our target (or source).  If so,
-// chain: source → intermediate + intermediate → target (the latter being a
+// chain: source to intermediate + intermediate to target (the latter being a
 // simple unit/axis conversion handled by createOperationsVertToVert).
 //
-// Typical example: Baltic 1977 height (EPSG:5705) → Caspian depth (EPSG:5706).
-// EPSG has an operation 5705 → 5611 (Caspian height).  5611 and 5706 share the
+// Typical example: Baltic 1977 height (EPSG:5705) to Caspian depth (EPSG:5706).
+// EPSG has an operation 5705 to 5611 (Caspian height).  5611 and 5706 share the
 // same datum but differ only in axis direction.  We compose:
-//   5705 →(EPSG:5438)→ 5611 →(height-to-depth)→ 5706
+//   5705 ->(EPSG:5438)-> 5611 ->(height-to-depth)-> 5706
 std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     createOperationsVertToVertWithIntermediateVert(
         const crs::CRSNNPtr &sourceCRS,
@@ -4591,7 +4591,7 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
     for (const auto &candidateVert : candidatesDst) {
         if (candidateVert->_isEquivalentTo(
                 targetCRS.get(), util::IComparable::Criterion::EQUIVALENT)) {
-            continue; // Skip the target itself — already tried by the caller.
+            continue; // Skip the target itself (already tried by the caller)
         }
         auto opsFirst = createOperations(sourceCRS, sourceEpoch, candidateVert,
                                          sourceEpoch, context);

--- a/src/iso19111/operation/coordinateoperationfactory.cpp
+++ b/src/iso19111/operation/coordinateoperationfactory.cpp
@@ -4600,16 +4600,15 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
             }
             // Collect all registered source-to-candidate operations, which
             // may differ in accuracy or area of use, for later ranking.
-            auto opsFirst = createOperations(sourceCRS, sourceEpoch,
-                                             candidateVert, sourceEpoch,
-                                             context);
+            auto opsFirst = createOperations(
+                sourceCRS, sourceEpoch, candidateVert, sourceEpoch, context);
             if (!opsFirst.empty()) {
                 // The candidate-to-target conversion is expected to be a
                 // trivial unit or axis change, so we only use the first
                 // result (opsSecond.front()).
-                const auto opsSecond = createOperations(
-                    candidateVert, sourceEpoch, targetCRS, targetEpoch,
-                    context);
+                const auto opsSecond =
+                    createOperations(candidateVert, sourceEpoch, targetCRS,
+                                     targetEpoch, context);
                 if (!opsSecond.empty()) {
                     for (const auto &opFirst : opsFirst) {
                         if (hasIdentifiers(opFirst)) {
@@ -4645,9 +4644,9 @@ std::vector<CoordinateOperationNNPtr> CoordinateOperationFactory::Private::
             auto opsSecond = createOperations(candidateVert, sourceEpoch,
                                               targetCRS, targetEpoch, context);
             if (!opsSecond.empty()) {
-                const auto opsFirst = createOperations(
-                    sourceCRS, sourceEpoch, candidateVert, sourceEpoch,
-                    context);
+                const auto opsFirst =
+                    createOperations(sourceCRS, sourceEpoch, candidateVert,
+                                     sourceEpoch, context);
                 if (!opsFirst.empty()) {
                     for (const auto &opSecond : opsSecond) {
                         if (hasIdentifiers(opSecond)) {

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7275,13 +7275,15 @@ TEST(operation, vertCRS_to_vertCRS_New_Zealand_context) {
 
 // ---------------------------------------------------------------------------
 
-TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
+TEST(operation, vertCRS_to_vertCRS_pivot_context) {
     // Test that PROJ can chain a registered vertical CT with a
     // height-to-depth axis conversion when the target CRS differs from
     // the CT's registered target only by axis direction.
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    ctxt->setSpatialCriterion(
+        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
 
     auto checkPipeline = [&](const std::string &srcCode,
                              const std::string &tgtCode,
@@ -7296,28 +7298,20 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
             expectedProj);
     };
 
+    // Using Strategy 1 of createOperationsVertToVertWithIntermediateVert()
+
     // Caspian: EPSG:5705 (Baltic 1977 height) -> EPSG:5706 (Caspian depth)
     // via EPSG:5438 (dh=28) + height-to-depth axisswap
     checkPipeline("5705", "5706",
                   "+proj=pipeline +step +proj=geogoffset +dh=28 "
                   "+step +proj=axisswap +order=1,2,-3");
 
-    // AIOC95: EPSG:5705 -> EPSG:5734 (AIOC95 depth)
-    // via EPSG:5443 (dh=26.3) + height-to-depth axisswap
-    checkPipeline("5705", "5734",
-                  "+proj=pipeline +step +proj=geogoffset +dh=26.3 "
-                  "+step +proj=axisswap +order=1,2,-3");
-
-    // KOC: EPSG:5790 (KOC CD height) -> EPSG:5789 (KOC WD depth)
-    // via EPSG:7986 (dh=-4.74) + height-to-depth axisswap
-    checkPipeline("5790", "5789",
-                  "+proj=pipeline +step +proj=geogoffset +dh=-4.74 "
-                  "+step +proj=axisswap +order=1,2,-3");
-
-    // Kuwait PWD: EPSG:5788 -> EPSG:5789 (KOC WD depth)
-    // via EPSG:7981 (dh=-4.25) + height-to-depth axisswap
-    checkPipeline("5788", "5789",
-                  "+proj=pipeline +step +proj=geogoffset +dh=-4.25 "
+    // Caspian: EPSG:5706 (Caspian depth) -> EPSG:5705 (Baltic 1977 height)
+    // axisswap + inverse of EPSG:5438 (dh=-28)
+    // Note: yes that pipeline is identical to the above one, since it is its
+    // own inverse.
+    checkPipeline("5706", "5705",
+                  "+proj=pipeline +step +proj=geogoffset +dh=28 "
                   "+step +proj=axisswap +order=1,2,-3");
 
     // KOC ft: EPSG:5790 -> EPSG:5614 (KOC WD depth ft)
@@ -7327,55 +7321,6 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
                   "+step +proj=geogoffset +dh=-4.74 "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=unitconvert +z_in=m +z_out=ft");
-}
-
-// ---------------------------------------------------------------------------
-
-TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_context) {
-    // Test the reverse direction: depth to height.
-    // When the source is depth (axis DOWN) and the target is height (axis UP),
-    // the code prefers pivoting through the SOURCE's datum, composing:
-    // depth-to-height axisswap + inverse of the registered forward op.
-    auto authFactory =
-        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
-    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
-
-    auto checkPipeline = [&](const std::string &srcCode,
-                             const std::string &tgtCode,
-                             const std::string &expectedProj) {
-        auto list = CoordinateOperationFactory::create()->createOperations(
-            authFactory->createCoordinateReferenceSystem(srcCode),
-            authFactory->createCoordinateReferenceSystem(tgtCode), ctxt);
-        ASSERT_GE(list.size(), 1U);
-        EXPECT_FALSE(list[0]->hasBallparkTransformation());
-        EXPECT_EQ(
-            list[0]->exportToPROJString(PROJStringFormatter::create().get()),
-            expectedProj);
-    };
-
-    // Caspian: EPSG:5706 (Caspian depth) -> EPSG:5705 (Baltic 1977 height)
-    // axisswap + inverse of EPSG:5438 (dh=-28)
-    checkPipeline("5706", "5705",
-                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                  "+step +proj=geogoffset +dh=-28");
-
-    // AIOC95: EPSG:5734 (AIOC95 depth) -> EPSG:5705 (Baltic 1977 height)
-    // axisswap + inverse of EPSG:5443 (dh=-26.3)
-    checkPipeline("5734", "5705",
-                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                  "+step +proj=geogoffset +dh=-26.3");
-
-    // KOC: EPSG:5789 (KOC WD depth) -> EPSG:5790 (KOC CD height)
-    // axisswap + inverse of EPSG:7986 (dh=4.74)
-    checkPipeline("5789", "5790",
-                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                  "+step +proj=geogoffset +dh=4.74");
-
-    // Kuwait PWD: EPSG:5789 (KOC WD depth) -> EPSG:5788 (Kuwait PWD height)
-    // axisswap + inverse of EPSG:7981 (dh=4.25)
-    checkPipeline("5789", "5788",
-                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                  "+step +proj=geogoffset +dh=4.25");
 
     // KOC ft: EPSG:5614 (KOC WD depth ft) -> EPSG:5790 (KOC CD height)
     // unit conversion ft->m + axisswap + inverse of EPSG:7987 (dh=4.74)
@@ -7384,62 +7329,24 @@ TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_context) {
                   "+step +proj=unitconvert +z_in=ft +z_out=m "
                   "+step +proj=axisswap +order=1,2,-3 "
                   "+step +proj=geogoffset +dh=4.74");
-}
 
-// ---------------------------------------------------------------------------
-
-TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_blacksea_context) {
-    // Test that the intermediate-vert pivot finds a registered cross-datum
-    // height-to-height transformation and composes it with an axis reversal.
-    //
     // EPSG:5705 (Baltic 1977 height) to EPSG:5336 (Black Sea depth)
     // Strategy 1 composes: EPSG:5447 (5705 to 5735, geogoffset +dh=0.4)
     //                    + height-to-depth (axisswap order=1,2,-3)
-    // PARTIAL_INTERSECTION is needed because EPSG:5447's area
-    // is slightly smaller than EPSG:5336's extent
-    auto authFactory =
-        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
-    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
-    ctxt->setSpatialCriterion(
-        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
-    auto list = CoordinateOperationFactory::create()->createOperations(
-        // Baltic 1977 height
-        authFactory->createCoordinateReferenceSystem("5705"),
-        // Black Sea depth
-        authFactory->createCoordinateReferenceSystem("5336"), ctxt);
-    ASSERT_GE(list.size(), 1U);
-    EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    auto projStr =
-        list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=0.4 +step "
-                       "+proj=axisswap +order=1,2,-3");
-}
+    checkPipeline("5705", "5336",
+                  "+proj=pipeline "
+                  "+step +proj=geogoffset +dh=0.4 "
+                  "+step +proj=axisswap +order=1,2,-3");
 
-// ---------------------------------------------------------------------------
+    // Using Strategy 2 of createOperationsVertToVertWithIntermediateVert()
 
-TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_blacksea_context) {
-    // Test the reverse direction for the Black Sea case.
-    //
     // EPSG:5336 (Black Sea depth) to EPSG:5705 (Baltic 1977 height)
     // Strategy 2 composes: depth-to-height (5336 to 5735, axisswap)
     //                    + inverse of EPSG:5447 (5735 to 5705, dh=-0.4)
-
-    auto authFactory =
-        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
-    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
-    ctxt->setSpatialCriterion(
-        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
-    auto list = CoordinateOperationFactory::create()->createOperations(
-        // Black Sea depth
-        authFactory->createCoordinateReferenceSystem("5336"),
-        // Baltic 1977 height
-        authFactory->createCoordinateReferenceSystem("5705"), ctxt);
-    ASSERT_GE(list.size(), 1U);
-    EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    auto projStr =
-        list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                       "+step +proj=geogoffset +dh=-0.4");
+    checkPipeline("5336", "5705",
+                  "+proj=pipeline "
+                  "+step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=-0.4");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7303,6 +7303,34 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
 
 // ---------------------------------------------------------------------------
 
+TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_strategy2_context) {
+    // Test Strategy 2: pivot through a candidate sharing the SOURCE's datum.
+    //
+    // EPSG:5706 (Caspian depth) → EPSG:5705 (Baltic 1977 height)
+    // The registered operation EPSG:5438 goes 5705 → 5611 (Caspian height).
+    // Strategy 2 finds 5611 (shares Caspian datum with source 5706), discovers
+    // the reverse of EPSG:5438 from 5611 → 5705, and composes:
+    //   5706 →(depth-to-height)→ 5611 →(reverse 5438)→ 5705
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    auto list = CoordinateOperationFactory::create()->createOperations(
+        // Caspian depth
+        authFactory->createCoordinateReferenceSystem("5706"),
+        // Baltic 1977 height
+        authFactory->createCoordinateReferenceSystem("5705"), ctxt);
+    ASSERT_GE(list.size(), 1U);
+    // Must NOT be a ballpark transformation
+    EXPECT_FALSE(list[0]->hasBallparkTransformation());
+    // The pipeline should contain axisswap (depth→height) and geogoffset
+    auto projStr =
+        list[0]->exportToPROJString(PROJStringFormatter::create().get());
+    EXPECT_TRUE(projStr.find("geogoffset") != std::string::npos) << projStr;
+    EXPECT_TRUE(projStr.find("axisswap") != std::string::npos) << projStr;
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(operation, projCRS_3D_to_geogCRS_3D) {
 
     auto compoundcrs_ft_obj = PROJStringParser().createFromPROJString(

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7277,11 +7277,11 @@ TEST(operation, vertCRS_to_vertCRS_New_Zealand_context) {
 
 TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
     // Test that PROJ can chain a registered vertical CT with a
-    // height↔depth axis conversion when the target CRS differs from
+    // height-to-depth axis conversion when the target CRS differs from
     // the CT's registered target only by axis direction.
     //
-    // EPSG:5705 (Baltic 1977 height) → EPSG:5706 (Caspian depth)
-    // should compose: EPSG:5438 (5705→5611, geogoffset +dh=28)
+    // EPSG:5705 (Baltic 1977 height) to EPSG:5706 (Caspian depth)
+    // should compose: EPSG:5438 (5705 to 5611, geogoffset +dh=28)
     //               + height-to-depth (axisswap order=1,2,-3)
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");
@@ -7294,11 +7294,12 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
     ASSERT_GE(list.size(), 1U);
     // Must NOT be a ballpark transformation
     EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    // The pipeline should contain geogoffset +dh=28 and axisswap
+    // The pipeline should match the registered operation followed by the
+    // height-to-depth axis conversion.
     auto projStr =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_TRUE(projStr.find("geogoffset") != std::string::npos) << projStr;
-    EXPECT_TRUE(projStr.find("axisswap") != std::string::npos) << projStr;
+    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=28 +step "
+                       "+proj=axisswap +order=1,2,-3");
 }
 
 // ---------------------------------------------------------------------------
@@ -7306,11 +7307,12 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
 TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_strategy2_context) {
     // Test Strategy 2: pivot through a candidate sharing the SOURCE's datum.
     //
-    // EPSG:5706 (Caspian depth) → EPSG:5705 (Baltic 1977 height)
-    // The registered operation EPSG:5438 goes 5705 → 5611 (Caspian height).
+    // EPSG:5706 (Caspian depth) to EPSG:5705 (Baltic 1977 height)
+    // The registered operation EPSG:5438 goes 5705 to 5611 (Caspian height).
     // Strategy 2 finds 5611 (shares Caspian datum with source 5706), discovers
-    // the reverse of EPSG:5438 from 5611 → 5705, and composes:
-    //   5706 →(depth-to-height)→ 5611 →(reverse 5438)→ 5705
+    // the reverse of EPSG:5438 from 5611 to 5705, and composes:
+    //   5706 -(depth-to-height conversion)-> 5611 -(inverse of EPSG:5438)->
+    //   5705
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
@@ -7322,11 +7324,12 @@ TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_strategy2_context) {
     ASSERT_GE(list.size(), 1U);
     // Must NOT be a ballpark transformation
     EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    // The pipeline should contain axisswap (depth→height) and geogoffset
+    // The exported pipeline is normalized to the same PROJ steps as the
+    // forward case.
     auto projStr =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_TRUE(projStr.find("geogoffset") != std::string::npos) << projStr;
-    EXPECT_TRUE(projStr.find("axisswap") != std::string::npos) << projStr;
+    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=28 +step "
+                       "+proj=axisswap +order=1,2,-3");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7279,57 +7279,167 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
     // Test that PROJ can chain a registered vertical CT with a
     // height-to-depth axis conversion when the target CRS differs from
     // the CT's registered target only by axis direction.
-    //
-    // EPSG:5705 (Baltic 1977 height) to EPSG:5706 (Caspian depth)
-    // should compose: EPSG:5438 (5705 to 5611, geogoffset +dh=28)
-    //               + height-to-depth (axisswap order=1,2,-3)
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+
+    auto checkPipeline = [&](const std::string &srcCode,
+                             const std::string &tgtCode,
+                             const std::string &expectedProj) {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            authFactory->createCoordinateReferenceSystem(srcCode),
+            authFactory->createCoordinateReferenceSystem(tgtCode), ctxt);
+        ASSERT_GE(list.size(), 1U);
+        EXPECT_FALSE(list[0]->hasBallparkTransformation());
+        EXPECT_EQ(
+            list[0]->exportToPROJString(PROJStringFormatter::create().get()),
+            expectedProj);
+    };
+
+    // Caspian: EPSG:5705 (Baltic 1977 height) -> EPSG:5706 (Caspian depth)
+    // via EPSG:5438 (dh=28) + height-to-depth axisswap
+    checkPipeline("5705", "5706",
+                     "+proj=pipeline +step +proj=geogoffset +dh=28 "
+                     "+step +proj=axisswap +order=1,2,-3");
+
+    // AIOC95: EPSG:5705 -> EPSG:5734 (AIOC95 depth)
+    // via EPSG:5443 (dh=26.3) + height-to-depth axisswap
+    checkPipeline("5705", "5734",
+                     "+proj=pipeline +step +proj=geogoffset +dh=26.3 "
+                     "+step +proj=axisswap +order=1,2,-3");
+
+    // KOC: EPSG:5790 (KOC CD height) -> EPSG:5789 (KOC WD depth)
+    // via EPSG:7986 (dh=-4.74) + height-to-depth axisswap
+    checkPipeline("5790", "5789",
+                     "+proj=pipeline +step +proj=geogoffset +dh=-4.74 "
+                     "+step +proj=axisswap +order=1,2,-3");
+
+    // Kuwait PWD: EPSG:5788 -> EPSG:5789 (KOC WD depth)
+    // via EPSG:7981 (dh=-4.25) + height-to-depth axisswap
+    checkPipeline("5788", "5789",
+                     "+proj=pipeline +step +proj=geogoffset +dh=-4.25 "
+                     "+step +proj=axisswap +order=1,2,-3");
+
+    // KOC ft: EPSG:5790 -> EPSG:5614 (KOC WD depth ft)
+    // via EPSG:7987 (dh=-4.74) + axisswap + unit conversion m->ft
+    checkPipeline("5790", "5614",
+                     "+proj=pipeline "
+                     "+step +proj=geogoffset +dh=-4.74 "
+                     "+step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=unitconvert +z_in=m +z_out=ft");
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_context) {
+    // Test the reverse direction: depth to height.
+    // When the source is depth (axis DOWN) and the target is height (axis UP),
+    // the code prefers pivoting through the SOURCE's datum, composing:
+    // depth-to-height axisswap + inverse of the registered forward op.
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+
+    auto checkPipeline = [&](const std::string &srcCode,
+                             const std::string &tgtCode,
+                             const std::string &expectedProj) {
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            authFactory->createCoordinateReferenceSystem(srcCode),
+            authFactory->createCoordinateReferenceSystem(tgtCode), ctxt);
+        ASSERT_GE(list.size(), 1U);
+        EXPECT_FALSE(list[0]->hasBallparkTransformation());
+        EXPECT_EQ(
+            list[0]->exportToPROJString(PROJStringFormatter::create().get()),
+            expectedProj);
+    };
+
+    // Caspian: EPSG:5706 (Caspian depth) -> EPSG:5705 (Baltic 1977 height)
+    // axisswap + inverse of EPSG:5438 (dh=-28)
+    checkPipeline("5706", "5705",
+                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=geogoffset +dh=-28");
+
+    // AIOC95: EPSG:5734 (AIOC95 depth) -> EPSG:5705 (Baltic 1977 height)
+    // axisswap + inverse of EPSG:5443 (dh=-26.3)
+    checkPipeline("5734", "5705",
+                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=geogoffset +dh=-26.3");
+
+    // KOC: EPSG:5789 (KOC WD depth) -> EPSG:5790 (KOC CD height)
+    // axisswap + inverse of EPSG:7986 (dh=4.74)
+    checkPipeline("5789", "5790",
+                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=geogoffset +dh=4.74");
+
+    // Kuwait PWD: EPSG:5789 (KOC WD depth) -> EPSG:5788 (Kuwait PWD height)
+    // axisswap + inverse of EPSG:7981 (dh=4.25)
+    checkPipeline("5789", "5788",
+                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=geogoffset +dh=4.25");
+
+    // KOC ft: EPSG:5614 (KOC WD depth ft) -> EPSG:5790 (KOC CD height)
+    // unit conversion ft->m + axisswap + inverse of EPSG:7987 (dh=4.74)
+    checkPipeline("5614", "5790",
+                     "+proj=pipeline "
+                     "+step +proj=unitconvert +z_in=ft +z_out=m "
+                     "+step +proj=axisswap +order=1,2,-3 "
+                     "+step +proj=geogoffset +dh=4.74");
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_blacksea_context) {
+    // Test that the intermediate-vert pivot finds a registered cross-datum
+    // height-to-height transformation and composes it with an axis reversal.
+    //
+    // EPSG:5705 (Baltic 1977 height) to EPSG:5336 (Black Sea depth)
+    // Strategy 1 composes: EPSG:5447 (5705 to 5735, geogoffset +dh=0.4)
+    //                    + height-to-depth (axisswap order=1,2,-3)
+    // PARTIAL_INTERSECTION is needed because EPSG:5447's area 
+    // is slightly smaller than EPSG:5336's extent
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    ctxt->setSpatialCriterion(
+        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
     auto list = CoordinateOperationFactory::create()->createOperations(
         // Baltic 1977 height
         authFactory->createCoordinateReferenceSystem("5705"),
-        // Caspian depth (same datum as Caspian height 5611, but axis: down)
-        authFactory->createCoordinateReferenceSystem("5706"), ctxt);
+        // Black Sea depth
+        authFactory->createCoordinateReferenceSystem("5336"), ctxt);
     ASSERT_GE(list.size(), 1U);
-    // Must NOT be a ballpark transformation
     EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    // The pipeline should match the registered operation followed by the
-    // height-to-depth axis conversion.
     auto projStr =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=28 +step "
+    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=0.4 +step "
                        "+proj=axisswap +order=1,2,-3");
 }
 
 // ---------------------------------------------------------------------------
 
-TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_strategy2_context) {
-    // Test Strategy 2: pivot through a candidate sharing the SOURCE's datum.
+TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_blacksea_context) {
+    // Test the reverse direction for the Black Sea case.
     //
-    // EPSG:5706 (Caspian depth) to EPSG:5705 (Baltic 1977 height)
-    // The registered operation EPSG:5438 goes 5705 to 5611 (Caspian height).
-    // Strategy 2 finds 5611 (shares Caspian datum with source 5706), discovers
-    // the reverse of EPSG:5438 from 5611 to 5705, and composes:
-    //   5706 -(depth-to-height conversion)-> 5611 -(inverse of EPSG:5438)->
-    //   5705
+    // EPSG:5336 (Black Sea depth) to EPSG:5705 (Baltic 1977 height)
+    // Strategy 2 composes: depth-to-height (5336 to 5735, axisswap)
+    //                    + inverse of EPSG:5447 (5735 to 5705, dh=-0.4)
+
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");
     auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    ctxt->setSpatialCriterion(
+        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
     auto list = CoordinateOperationFactory::create()->createOperations(
-        // Caspian depth
-        authFactory->createCoordinateReferenceSystem("5706"),
+        // Black Sea depth
+        authFactory->createCoordinateReferenceSystem("5336"),
         // Baltic 1977 height
         authFactory->createCoordinateReferenceSystem("5705"), ctxt);
     ASSERT_GE(list.size(), 1U);
-    // Must NOT be a ballpark transformation
     EXPECT_FALSE(list[0]->hasBallparkTransformation());
-    // The exported pipeline is normalized to the same PROJ steps as the
-    // forward case.
     auto projStr =
         list[0]->exportToPROJString(PROJStringFormatter::create().get());
-    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=geogoffset +dh=28 +step "
-                       "+proj=axisswap +order=1,2,-3");
+    EXPECT_EQ(projStr, "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                       "+step +proj=geogoffset +dh=-0.4");
 }
 
 // ---------------------------------------------------------------------------

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7299,34 +7299,34 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
     // Caspian: EPSG:5705 (Baltic 1977 height) -> EPSG:5706 (Caspian depth)
     // via EPSG:5438 (dh=28) + height-to-depth axisswap
     checkPipeline("5705", "5706",
-                     "+proj=pipeline +step +proj=geogoffset +dh=28 "
-                     "+step +proj=axisswap +order=1,2,-3");
+                  "+proj=pipeline +step +proj=geogoffset +dh=28 "
+                  "+step +proj=axisswap +order=1,2,-3");
 
     // AIOC95: EPSG:5705 -> EPSG:5734 (AIOC95 depth)
     // via EPSG:5443 (dh=26.3) + height-to-depth axisswap
     checkPipeline("5705", "5734",
-                     "+proj=pipeline +step +proj=geogoffset +dh=26.3 "
-                     "+step +proj=axisswap +order=1,2,-3");
+                  "+proj=pipeline +step +proj=geogoffset +dh=26.3 "
+                  "+step +proj=axisswap +order=1,2,-3");
 
     // KOC: EPSG:5790 (KOC CD height) -> EPSG:5789 (KOC WD depth)
     // via EPSG:7986 (dh=-4.74) + height-to-depth axisswap
     checkPipeline("5790", "5789",
-                     "+proj=pipeline +step +proj=geogoffset +dh=-4.74 "
-                     "+step +proj=axisswap +order=1,2,-3");
+                  "+proj=pipeline +step +proj=geogoffset +dh=-4.74 "
+                  "+step +proj=axisswap +order=1,2,-3");
 
     // Kuwait PWD: EPSG:5788 -> EPSG:5789 (KOC WD depth)
     // via EPSG:7981 (dh=-4.25) + height-to-depth axisswap
     checkPipeline("5788", "5789",
-                     "+proj=pipeline +step +proj=geogoffset +dh=-4.25 "
-                     "+step +proj=axisswap +order=1,2,-3");
+                  "+proj=pipeline +step +proj=geogoffset +dh=-4.25 "
+                  "+step +proj=axisswap +order=1,2,-3");
 
     // KOC ft: EPSG:5790 -> EPSG:5614 (KOC WD depth ft)
     // via EPSG:7987 (dh=-4.74) + axisswap + unit conversion m->ft
     checkPipeline("5790", "5614",
-                     "+proj=pipeline "
-                     "+step +proj=geogoffset +dh=-4.74 "
-                     "+step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=unitconvert +z_in=m +z_out=ft");
+                  "+proj=pipeline "
+                  "+step +proj=geogoffset +dh=-4.74 "
+                  "+step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=unitconvert +z_in=m +z_out=ft");
 }
 
 // ---------------------------------------------------------------------------
@@ -7356,34 +7356,34 @@ TEST(operation, vertCRS_to_vertCRS_depth_height_pivot_context) {
     // Caspian: EPSG:5706 (Caspian depth) -> EPSG:5705 (Baltic 1977 height)
     // axisswap + inverse of EPSG:5438 (dh=-28)
     checkPipeline("5706", "5705",
-                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=geogoffset +dh=-28");
+                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=-28");
 
     // AIOC95: EPSG:5734 (AIOC95 depth) -> EPSG:5705 (Baltic 1977 height)
     // axisswap + inverse of EPSG:5443 (dh=-26.3)
     checkPipeline("5734", "5705",
-                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=geogoffset +dh=-26.3");
+                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=-26.3");
 
     // KOC: EPSG:5789 (KOC WD depth) -> EPSG:5790 (KOC CD height)
     // axisswap + inverse of EPSG:7986 (dh=4.74)
     checkPipeline("5789", "5790",
-                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=geogoffset +dh=4.74");
+                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=4.74");
 
     // Kuwait PWD: EPSG:5789 (KOC WD depth) -> EPSG:5788 (Kuwait PWD height)
     // axisswap + inverse of EPSG:7981 (dh=4.25)
     checkPipeline("5789", "5788",
-                     "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=geogoffset +dh=4.25");
+                  "+proj=pipeline +step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=4.25");
 
     // KOC ft: EPSG:5614 (KOC WD depth ft) -> EPSG:5790 (KOC CD height)
     // unit conversion ft->m + axisswap + inverse of EPSG:7987 (dh=4.74)
     checkPipeline("5614", "5790",
-                     "+proj=pipeline "
-                     "+step +proj=unitconvert +z_in=ft +z_out=m "
-                     "+step +proj=axisswap +order=1,2,-3 "
-                     "+step +proj=geogoffset +dh=4.74");
+                  "+proj=pipeline "
+                  "+step +proj=unitconvert +z_in=ft +z_out=m "
+                  "+step +proj=axisswap +order=1,2,-3 "
+                  "+step +proj=geogoffset +dh=4.74");
 }
 
 // ---------------------------------------------------------------------------
@@ -7395,7 +7395,7 @@ TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_blacksea_context) {
     // EPSG:5705 (Baltic 1977 height) to EPSG:5336 (Black Sea depth)
     // Strategy 1 composes: EPSG:5447 (5705 to 5735, geogoffset +dh=0.4)
     //                    + height-to-depth (axisswap order=1,2,-3)
-    // PARTIAL_INTERSECTION is needed because EPSG:5447's area 
+    // PARTIAL_INTERSECTION is needed because EPSG:5447's area
     // is slightly smaller than EPSG:5336's extent
     auto authFactory =
         AuthorityFactory::create(DatabaseContext::create(), "EPSG");

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -7275,6 +7275,34 @@ TEST(operation, vertCRS_to_vertCRS_New_Zealand_context) {
 
 // ---------------------------------------------------------------------------
 
+TEST(operation, vertCRS_to_vertCRS_height_depth_pivot_context) {
+    // Test that PROJ can chain a registered vertical CT with a
+    // height↔depth axis conversion when the target CRS differs from
+    // the CT's registered target only by axis direction.
+    //
+    // EPSG:5705 (Baltic 1977 height) → EPSG:5706 (Caspian depth)
+    // should compose: EPSG:5438 (5705→5611, geogoffset +dh=28)
+    //               + height-to-depth (axisswap order=1,2,-3)
+    auto authFactory =
+        AuthorityFactory::create(DatabaseContext::create(), "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    auto list = CoordinateOperationFactory::create()->createOperations(
+        // Baltic 1977 height
+        authFactory->createCoordinateReferenceSystem("5705"),
+        // Caspian depth (same datum as Caspian height 5611, but axis: down)
+        authFactory->createCoordinateReferenceSystem("5706"), ctxt);
+    ASSERT_GE(list.size(), 1U);
+    // Must NOT be a ballpark transformation
+    EXPECT_FALSE(list[0]->hasBallparkTransformation());
+    // The pipeline should contain geogoffset +dh=28 and axisswap
+    auto projStr =
+        list[0]->exportToPROJString(PROJStringFormatter::create().get());
+    EXPECT_TRUE(projStr.find("geogoffset") != std::string::npos) << projStr;
+    EXPECT_TRUE(projStr.find("axisswap") != std::string::npos) << projStr;
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(operation, projCRS_3D_to_geogCRS_3D) {
 
     auto compoundcrs_ft_obj = PROJStringParser().createFromPROJString(


### PR DESCRIPTION
## Summary

When transforming between two vertical CRSs and no direct registered operation exists for the exact pair, PROJ now searches for registered operations involving an intermediate vertical CRS that shares the same datum as the source or target. The intermediate CRS may differ in axis direction (height vs depth), units (metres vs feet), or both. Previously PROJ fell back to a ballpark transformation, discarding available registered operations.

- ✅ Closes #4707
- ✅ Tests added
- [x] Developed with AI-assistance (Claude Opus 4.6)

## Example

**EPSG:5705** (Baltic 1977 height) → **EPSG:5706** (Caspian depth)

EPSG:5438 transforms 5705 → 5611 (Caspian *height*). CRS 5611 and 5706 share the Caspian datum but differ in axis direction. PROJ now composes:

`5705 →(EPSG:5438)→ 5611 →(height-to-depth axisswap)→ 5706`

### Before (ballpark fallback)

> ```
> +proj=affine +s33=-1
> (50.0, 40.0, 100) → (50.0, 40.0, -100.0)  ← wrong
> ```

### After (registered operation + axis conversion)

> ```
> +proj=pipeline +step +proj=geogoffset +dh=28 +step +proj=axisswap +order=1,2,-3
> (50.0, 40.0, 100) → (50.0, 40.0, -128.0)  ← correct
> ```

## Implementation

New method `createOperationsVertToVertWithIntermediateVert` in `coordinateoperationfactory.cpp`, using two strategies:

1. **Pivot on target datum**: Find candidate vertical CRSs sharing the target's datum. If a registered operation exists from the source to any candidate, compose it with the candidate→target axis/unit conversion.
2. **Pivot on source datum**: Find candidate vertical CRSs sharing the source's datum. If a registered operation exists from any candidate to the target, compose the source→candidate conversion with that operation.

This mirrors the existing `createOperationsGeogToVertWithIntermediateVert` (geographic→vertical paths) but extends it to vertical→vertical paths. Uses the existing `findCandidateVertCRSForDatum` infrastructure.

## Changes

- **`src/iso19111/operation/coordinateoperationfactory.cpp`**: Added `createOperationsVertToVertWithIntermediateVert` method with anti-recursion guard; invoked from `createOperationsFromDatabaseWithVertCRS` when no direct result is found.
- **`test/unit/test_operationfactory.cpp`**: Two new tests — Strategy 1 (5705→5706, height→depth) and Strategy 2 (5706→5705, depth→height).
- **`NEWS.md`**: Added entry under 9.8.0 Updates.
- **`docs/source/operations/operations_computation.rst`**: Updated "Vertical CRS to a Vertical CRS" section documenting the new intermediate CRS pivot logic.