### PR TITLE
Workaround sqlite 3.53.0 regression on sqlite3_mprintf()

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2232,7 +2232,7 @@ std::vector<std::string> DatabaseContext::Private::getInsertStatementsFor(
 // ---------------------------------------------------------------------------
 
 static std::string anchorEpochToStr(double val) {
-    constexpr int BUF_SIZE = 16;
+    constexpr int BUF_SIZE = 32;
     char szBuffer[BUF_SIZE];
     sqlite3_snprintf(BUF_SIZE, szBuffer, "%.3f", val);
     return szBuffer;


### PR DESCRIPTION
See https://sqlite.org/forum/forumpost/e2421578f4

Breaks the factory.objectInsertion unit test, or more generally if using getInsertStatementsFor() with a geodetic datum with an anchor epoch. Which shouldn't affect that many people
