### PR TITLE
[Backport 9.8] Workaround sqlite 3.53.0 regression on sqlite3_mprintf()

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -2231,7 +2231,7 @@ std::vector<std::string> DatabaseContext::Private::getInsertStatementsFor(
 // ---------------------------------------------------------------------------
 
 static std::string anchorEpochToStr(double val) {
-    constexpr int BUF_SIZE = 16;
+    constexpr int BUF_SIZE = 32;
     char szBuffer[BUF_SIZE];
     sqlite3_snprintf(BUF_SIZE, szBuffer, "%.3f", val);
     return szBuffer;


### PR DESCRIPTION
Backport #4745
 **Authored by:** @rouault