### PR TITLE
[Backport 9.8] grids: Add a missing memory inclide for std::make_unique

### DIFF
--- a/src/grids.cpp
+++ b/src/grids.cpp
@@ -46,6 +46,7 @@
 #include <cstdint>
 #include <cstring>
 #include <limits>
+#include <memory>
 
 NS_PROJ_START
 


### PR DESCRIPTION
Backport #4748
 **Authored by:** @mwestphal