### PR TITLE
[Backport 9.8] Limit recursion depth in json::parse() to avoid stack call overflow on hostile data

### DIFF
--- a/src/apps/projsync.cpp
+++ b/src/apps/projsync.cpp
@@ -310,7 +310,12 @@ int main(int argc, char *argv[]) {
     }
 
     try {
-        const auto j = json::parse(text);
+        const auto j =
+            json::parse(text, [](int depth, json::parse_event_t, json &) {
+                if (depth >= 128)
+                    throw ParsingException("Too deep nesting in JSON content");
+                return true;
+            });
         bool foundMatchSourceIdCriterion = false;
         std::set<std::string> source_ids;
         bool foundMatchAreaOfUseCriterion = false;

--- a/src/iso19111/io.cpp
+++ b/src/iso19111/io.cpp
@@ -7717,7 +7717,11 @@ static BaseObjectNNPtr createFromUserInput(const std::string &text,
     if (!text.empty() && text[0] == '{') {
         json j;
         try {
-            j = json::parse(text);
+            j = json::parse(text, [](int depth, json::parse_event_t, json &) {
+                if (depth >= 128)
+                    throw ParsingException("Too deep nesting in JSON content");
+                return true;
+            });
         } catch (const std::exception &e) {
             throw ParsingException(e.what());
         }

--- a/src/transformations/defmodel_impl.hpp
+++ b/src/transformations/defmodel_impl.hpp
@@ -348,7 +348,11 @@ std::unique_ptr<MasterFile> MasterFile::parse(const std::string &text) {
     std::unique_ptr<MasterFile> dmmf(new MasterFile());
     json j;
     try {
-        j = json::parse(text);
+        j = json::parse(text, [](int depth, json::parse_event_t, json &) {
+            if (depth >= 128)
+                throw ParsingException("Too deep nesting in JSON content");
+            return true;
+        });
     } catch (const std::exception &e) {
         throw ParsingException(e.what());
     }

--- a/src/transformations/tinshift_impl.hpp
+++ b/src/transformations/tinshift_impl.hpp
@@ -80,7 +80,11 @@ std::unique_ptr<TINShiftFile> TINShiftFile::parse(const std::string &text) {
     std::unique_ptr<TINShiftFile> tinshiftFile(new TINShiftFile());
     json j;
     try {
-        j = json::parse(text);
+        j = json::parse(text, [](int depth, json::parse_event_t, json &) {
+            if (depth >= 128)
+                throw ParsingException("Too deep nesting in JSON content");
+            return true;
+        });
     } catch (const std::exception &e) {
         throw ParsingException(e.what());
     }


### PR DESCRIPTION
Backport #4765
 **Authored by:** @rouault