### PR TITLE
Add get_build_git_revision in emscripten compilation

### DIFF
--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Run docker build
         run: |
           docker run --user $(id -u):$(id -g) --rm \
+            -e GITHUB_SHA=${{ github.sha }} \
             -v "$PWD":/build/proj_src \
             -v "$PWD"/wasm_out:/build/install \
             proj-emscripten-builder

--- a/scripts/ci/emscripten/build_wasm.sh
+++ b/scripts/ci/emscripten/build_wasm.sh
@@ -250,6 +250,17 @@ fi
 # Helper functions to extract some info from PROJ in C and C++
 log_step "6.5 Creating C Wrapper Functions"
 
+# --- Determine Git Revision ---
+GIT_REV=""
+if [ -n "${GITHUB_SHA}" ]; then
+    GIT_REV="${GITHUB_SHA}"
+else
+    if git rev-parse HEAD >/dev/null 2>&1; then
+        GIT_REV=$(git rev-parse HEAD)
+    fi
+fi
+echo "GIT_REV=${GIT_REV}"
+
 WRAPPER_FILE="${TEMP_BUILD_DIR}/proj_wrappers.cpp"
 WRAPPER_OBJ_FILE="${TEMP_BUILD_DIR}/proj_wrappers.o"
 
@@ -308,6 +319,10 @@ const char* get_compilation_date() {
     return "$DDD" ;
 }
 
+const char* get_build_git_revision() {
+    return "${GIT_REV}";
+}
+
 int get_ptr_size() {
     return sizeof(void*);
 }
@@ -334,7 +349,7 @@ FINAL_LIBS="${INSTALL_DIR}/lib/libproj.a \
             ${WRAPPER_OBJ_FILE}"
 
 # include all exported symbols
-echo -e "_malloc\n_free\n_get_compilation_date\n_get_ptr_size" > ${INSTALL_DIR}/exported_symbols.txt
+echo -e "_malloc\n_free\n_get_compilation_date\n_get_build_git_revision\n_get_ptr_size" > ${INSTALL_DIR}/exported_symbols.txt
 grep "^proj_\|^geod_" ${PROJ_SRC_DIR}/scripts/reference_exported_symbols.txt | grep -v "(" | sed 's/^/_/' >> ${INSTALL_DIR}/exported_symbols.txt
 head ${INSTALL_DIR}/exported_symbols.txt
 


### PR DESCRIPTION
To be sure what is run in emscripten outputs, this change adds a function `get_build_git_revision` that returns the git revision.
It is oriented to be used in github actions, but not only. In case the git revision is not readable (due to git configuration) or directly not available (not a git clone), the returned value is an empty string.

Would this functionality be useful in any compilation?

 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated. -> I asked Gemini the best way to ask git the revision, knowing that there are corner cases. In github actions apparently it is better to use `${{ github.sha }}` than asking git directly.
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API
