### PR TITLE
Add git hash in release string

### DIFF
--- a/.github/workflows/clang_linux.yml
+++ b/.github/workflows/clang_linux.yml
@@ -54,4 +54,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-clang-${{ matrix.id }}-
 
       - name: Run
-        run: docker run -e CI -e TRAVIS_BUILD_DIR="$PWD" -e PROJ_CMAKE_BUILD_OPTIONS="$PROJ_CMAKE_BUILD_OPTIONS" -e WORK_DIR="$PWD" -e TRAVIS_OS_NAME=linux -e BUILD_NAME=linux_clang -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/clang_linux/start.sh
+        run: docker run -e PROJ_GITHUB_SHA=${{ github.sha }} -e CI -e TRAVIS_BUILD_DIR="$PWD" -e PROJ_CMAKE_BUILD_OPTIONS="$PROJ_CMAKE_BUILD_OPTIONS" -e WORK_DIR="$PWD" -e TRAVIS_OS_NAME=linux -e BUILD_NAME=linux_clang -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/clang_linux/start.sh

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -160,6 +160,8 @@ jobs:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
           file: ${{ matrix.dockerfile }}
+          build-args: |
+            PROJ_GITHUB_SHA=${{ github.sha }}
           platforms: linux/${{ steps.prep.outputs.ARCH }}
           tags: ${{ steps.prep_tags.outputs.tags }}
           labels: |

--- a/.github/workflows/emscripten.yml
+++ b/.github/workflows/emscripten.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Run docker build
         run: |
           docker run --user $(id -u):$(id -g) --rm \
-            -e GITHUB_SHA=${{ github.sha }} \
+            -e PROJ_GITHUB_SHA=${{ github.sha }} \
             -v "$PWD":/build/proj_src \
             -v "$PWD"/wasm_out:/build/install \
             proj-emscripten-builder

--- a/.github/workflows/fedora_rawhide.yml
+++ b/.github/workflows/fedora_rawhide.yml
@@ -34,4 +34,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-fedora_rawhide-
 
       - name: Run
-        run: docker run -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD fedora:rawhide $PWD/.github/workflows/fedora_rawhide/start.sh
+        run: docker run -e PROJ_GITHUB_SHA=${{ github.sha }} -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD fedora:rawhide $PWD/.github/workflows/fedora_rawhide/start.sh

--- a/.github/workflows/linux_gcc_32bit.yml
+++ b/.github/workflows/linux_gcc_32bit.yml
@@ -34,4 +34,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-gcc32bit-
 
       - name: Run
-        run: docker run -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/linux_gcc_32bit/start.sh
+        run: docker run -e PROJ_GITHUB_SHA=${{ github.sha }} -e CI -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:20.04 $PWD/.github/workflows/linux_gcc_32bit/start.sh

--- a/.github/workflows/mingw_w64.yml
+++ b/.github/workflows/mingw_w64.yml
@@ -34,4 +34,4 @@ jobs:
           restore-keys: ${{ runner.os }}-cache-mingw_w64-
 
       - name: Build
-        run: docker run -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:22.04 $PWD/.github/workflows/mingw_w64/start.sh
+        run: docker run -e PROJ_GITHUB_SHA=${{ github.sha }} -e CI -e TRAVIS_OS_NAME=linux -e BUILD_NAME=mingw_w64 -e WORK_DIR="$PWD" -v $PWD:$PWD ubuntu:22.04 $PWD/.github/workflows/mingw_w64/start.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ LABEL maintainer="Howard Butler <howard@hobu.co>"
 
 ARG DESTDIR="/build"
 
+ARG PROJ_GITHUB_SHA
+
 # Setup build env
 RUN apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --fix-missing --no-install-recommends \

--- a/cmake/ProjConfig.cmake
+++ b/cmake/ProjConfig.cmake
@@ -51,4 +51,54 @@ if(EXISTS ${AUTOCONF_PROJ_CONFIG_H})
     "before CMake's build.")
 endif()
 
+# Get the git hash to write it in the release message.
+set(PROJ_GIT_HASH "")
+if(DEFINED ENV{PROJ_GITHUB_SHA})
+    string(SUBSTRING "$ENV{PROJ_GITHUB_SHA}" 0 7 PROJ_GIT_HASH)
+else()
+    find_package(Git QUIET)
+    if(Git_FOUND AND EXISTS "${PROJ_SOURCE_DIR}/.git")
+        # Get the short hash
+        execute_process(
+            COMMAND ${GIT_EXECUTABLE} rev-parse --short HEAD
+            WORKING_DIRECTORY "${PROJ_SOURCE_DIR}"
+            RESULT_VARIABLE GIT_REV_RESULT
+            OUTPUT_VARIABLE PROJ_GIT_HASH
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+            ERROR_QUIET
+        )
+
+        if(GIT_REV_RESULT EQUAL 0)
+            # Check if the working directory is dirty
+            execute_process(
+                COMMAND ${GIT_EXECUTABLE} status --porcelain --untracked-files=no
+                WORKING_DIRECTORY "${PROJ_SOURCE_DIR}"
+                RESULT_VARIABLE GIT_STATUS_RESULT
+                OUTPUT_VARIABLE GIT_STATUS_OUTPUT
+                OUTPUT_STRIP_TRAILING_WHITESPACE
+                ERROR_QUIET
+            )
+
+            # If the command succeeds and outputs anything, the tree is dirty
+            if(GIT_STATUS_RESULT EQUAL 0 AND NOT GIT_STATUS_OUTPUT STREQUAL "")
+                string(APPEND PROJ_GIT_HASH "*")
+            endif()
+        else()
+            set(PROJ_GIT_HASH "")
+        endif()
+    endif()
+endif()
+if(PROJ_GIT_HASH)
+    add_compile_definitions(PROJ_GIT_HASH=\"${PROJ_GIT_HASH}\")
+endif()
+message(PROJ_GIT_HASH=\"${PROJ_GIT_HASH}\")
+
+# Tell CMake to re-configure if the Git HEAD or index changes
+if(Git_FOUND AND EXISTS "${PROJ_SOURCE_DIR}/.git")
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+        "${PROJ_SOURCE_DIR}/.git/HEAD" # for the hash
+        "${PROJ_SOURCE_DIR}/.git/index" # for the *
+    )
+endif()
+
 configure_file(cmake/proj_config.cmake.in src/proj_config.h)

--- a/scripts/ci/emscripten/build_wasm.sh
+++ b/scripts/ci/emscripten/build_wasm.sh
@@ -250,17 +250,6 @@ fi
 # Helper functions to extract some info from PROJ in C and C++
 log_step "6.5 Creating C Wrapper Functions"
 
-# --- Determine Git Revision ---
-GIT_REV=""
-if [ -n "${GITHUB_SHA}" ]; then
-    GIT_REV="${GITHUB_SHA}"
-else
-    if git rev-parse HEAD >/dev/null 2>&1; then
-        GIT_REV=$(git rev-parse HEAD)
-    fi
-fi
-echo "GIT_REV=${GIT_REV}"
-
 WRAPPER_FILE="${TEMP_BUILD_DIR}/proj_wrappers.cpp"
 WRAPPER_OBJ_FILE="${TEMP_BUILD_DIR}/proj_wrappers.o"
 
@@ -319,10 +308,6 @@ const char* get_compilation_date() {
     return "$DDD" ;
 }
 
-const char* get_build_git_revision() {
-    return "${GIT_REV}";
-}
-
 int get_ptr_size() {
     return sizeof(void*);
 }
@@ -349,7 +334,7 @@ FINAL_LIBS="${INSTALL_DIR}/lib/libproj.a \
             ${WRAPPER_OBJ_FILE}"
 
 # include all exported symbols
-echo -e "_malloc\n_free\n_get_compilation_date\n_get_build_git_revision\n_get_ptr_size" > ${INSTALL_DIR}/exported_symbols.txt
+echo -e "_malloc\n_free\n_get_compilation_date\n_get_ptr_size" > ${INSTALL_DIR}/exported_symbols.txt
 grep "^proj_\|^geod_" ${PROJ_SRC_DIR}/scripts/reference_exported_symbols.txt | grep -v "(" | sed 's/^/_/' >> ${INSTALL_DIR}/exported_symbols.txt
 head ${INSTALL_DIR}/exported_symbols.txt
 

--- a/src/release.cpp
+++ b/src/release.cpp
@@ -6,8 +6,15 @@
 #define STR_HELPER(x) #x
 #define STR(x) STR_HELPER(x)
 
-char const pj_release[] = "Rel. " STR(PROJ_VERSION_MAJOR) "." STR(
-    PROJ_VERSION_MINOR) "." STR(PROJ_VERSION_PATCH) ", "
-                                                    "September 15th, 2026";
+#ifdef PROJ_GIT_HASH
+#define PROJ_GIT_REV_STR " (" PROJ_GIT_HASH ")"
+#else
+#define PROJ_GIT_REV_STR ""
+#endif
+
+char const pj_release[] =
+    "Rel. " STR(PROJ_VERSION_MAJOR) "." STR(PROJ_VERSION_MINOR) "." STR(
+        PROJ_VERSION_PATCH) PROJ_GIT_REV_STR ", "
+                                             "September 15th, 2026";
 
 const char *pj_get_release() { return pj_release; }


### PR DESCRIPTION
 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated. -> gemini helped to call git in cmake.
- [ ] Closes #xxxx
- [ ] Tests added
- [x] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API

Continuing #4771 , this PR adds the git hash to the release string
For instance:
```
./bin/proj
Rel. 9.9.0 (a51f7b60), September 15th, 2026
usage: proj [-bdeEfiIlmorsStTvVwW [args]] [+opt[=arg] ...] [file ...]
```

In case the git tree is "dirty" (there are modified files), an asterisk `*` is added after the hash.
If this feature is not needed, it can be removed.
```
./bin/proj
Rel. 9.9.0 (a51f7b60*), September 15th, 2026
usage: proj [-bdeEfiIlmorsStTvVwW [args]] [+opt[=arg] ...] [file ...]
```

To help in the docker images, that may not have proper access to git, the environment variable `PROJ_GITHUB_SHA` is used before asking git for the revision. (`.git` is included in `.dockerignore`, so it is not found)