### PR TITLE
Clarify installation instructions: building from source, and guidance for packagers

### DIFF
--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -144,12 +144,8 @@ Alternatively, one can also check out the master branch or any other revision fr
 Note that some sections below presume an unpacked release tarball, and
 some say to use a git checkout.
 
-The following guides show how to compile and install the software using CMake.
-
-  .. note::
-
-    Support for Autotools was maintained until PROJ 8.2 (see :ref:`RFC7`).
-    PROJ 9.0 and later releases only support builds using CMake.
+As of PROJ 9.0, the only build system is CMake.  (The last release
+with Autotools was 8.2.)
 
 
 Requirements

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -4,10 +4,19 @@
 Installation
 ================================================================================
 
-These pages describe how to install PROJ on your computer without compiling it
-yourself. Below are guides for installing on Windows, Linux and Mac OS X. This
-is a good place to get started if this is your first time using PROJ. More
-advanced users may want to compile the software themselves.
+These pages describe how to install PROJ on your computer, covering a
+variety of operating systems.
+
+There is a section for using package management systems.  If PROJ is
+available for a package management system you already use, and you
+wish to run the release of PROJ offered by that system (usually that's
+fine), this is is the easiest path.
+
+There is a second section for building from source.  This section can
+be followed if there is no binary package available for your
+operating and CPU combination or if you wish to install a different
+version, including the tip of master in git, or pending fixes.  It is
+of course also useful to those creating packages.
 
 Installation from package management systems
 ################################################################################
@@ -130,6 +139,10 @@ Compilation and installation from source code
 
 The classic way of installing PROJ is via the source code distribution. The
 most recent version is available from the :ref:`download page<current_release>`.
+Alternatively, one can also check out the master branch or any other revision from GitHub.
+
+Note that some sections below presume an unpacked release tarball, and
+some say to use a git checkout.
 
 The following guides show how to compile and install the software using CMake.
 

--- a/docs/source/install.rst
+++ b/docs/source/install.rst
@@ -147,6 +147,9 @@ some say to use a git checkout.
 As of PROJ 9.0, the only build system is CMake.  (The last release
 with Autotools was 8.2.)
 
+Packagers and others with similar policy constraints should note that
+an outdated vendored copy of nlohmann/json may be used and that
+GoogleTest may be downloaded at build time (details below).
 
 Requirements
 --------------------------------------------------------------------------------
@@ -160,7 +163,7 @@ Build requirements
 - SQLite3 >= 3.11: headers and library for target architecture, and sqlite3 executable for build architecture
 - libtiff >= 4.0 (optional but recommended to enable reading of grid formats based on GeoTIFF. Only basic TIFF support is required; optional features like WebP or ZStd are not needed.)
 - curl >= 7.29.0 (optional but recommended to support automatic downloading of remote grid files during runtime, allowing PROJ to fetch required transformation data on demand.)
-- JSON for Modern C++ (nlohmann/json) >= 3.7.0
+- JSON for Modern C++ (nlohmann/json) >= 3.7.0 (a vendored 3.9.1 will be used if not found; use `-DNLOHMANN_JSON_ORIGIN=EXTERNAL` to prevent this)
 
 
 .. _test_requirements:
@@ -168,7 +171,7 @@ Build requirements
 Test requirements
 +++++++++++++++++
 
-These are only required if testing is built (see :option:`BUILD_TESTING`, default ON)
+If :option:`BUILD_TESTING` is ON (the default), test programs will be be compiled at build time, and the following additional dependencies are required:
 
 - GoogleTest (GTest) >= 1.8.1; if not found and :option:`TESTING_USE_NETWORK` is ON, then version 1.15.2 is fetched from GitHub and locally installed
 - Python >= 3.7


### PR DESCRIPTION
This PR contains multiple commits improving the installation instructions.  The big parts are rewording the start to say that it covers building from source (I almost stopped and went looking for that), and cautioning packagers about downloading and vendoring that is likely surprising and contrary to typical packaging system policy.

 - [ ] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
- [ x] Added clear title that can be used to generate release notes

(To be clear: there was no AI. I left it, unchecked, to state affirmatively that there was none.)