### PR TITLE
Fix CMake syntax for appending to CMAKE_<LANG>_FLAGS with Intel compilers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -129,8 +129,8 @@ endif()
 if (CMAKE_CXX_COMPILER_ID STREQUAL "IntelLLVM")
   # Intel CXX compiler based on clang defaults to -ffast-math, which
   # breaks std::isinf(), std::isnan(), etc.
-  set(CMAKE_C_FLAGS ${CMAKE_C_FLAGS} -fno-fast-math)
-  set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -fno-fast-math)
+  string(APPEND CMAKE_C_FLAGS " -fno-fast-math")
+  string(APPEND CMAKE_CXX_FLAGS " -fno-fast-math")
 endif ()
 
 # Add other supported compiler flags


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Added clear title that can be used to generate release notes

I ran into an issue where PROJ would not build on windows using the intel compilers, because the compiler would receive flags with wrong syntax. The issue is that [CMAKE_<LANG>_FLAGS](https://cmake.org/cmake/help/latest/variable/CMAKE_LANG_FLAGS.html) are: "a command-line string fragment. Therefore, multiple options should be separated by spaces, and options with spaces should be quoted." The current CMake commands perform a list append, which adds a semicolon in the string if CMAKE_C_FLAGS already contained something. I use string APPEND now, which was added in CMake 3.4, and you require version 3.16. 

I used Copilot to find the bug, I fixed it myself. My employer Deltares understands that this will be licensed under an MIT style license. Please let me know if I have to add a linked issue