### PR TITLE
Correct EPSG version from #4788

### DIFF
--- a/data/sql/metadata.sql
+++ b/data/sql/metadata.sql
@@ -9,7 +9,7 @@
 INSERT INTO "metadata" VALUES('DATABASE.LAYOUT.VERSION.MAJOR', 1);
 INSERT INTO "metadata" VALUES('DATABASE.LAYOUT.VERSION.MINOR', 7);
 
-INSERT INTO "metadata" VALUES('EPSG.VERSION', 'v12.055');
+INSERT INTO "metadata" VALUES('EPSG.VERSION', 'v12.057');
 INSERT INTO "metadata" VALUES('EPSG.DATE', '2026-06-18');
 
 -- The value of ${PROJ_VERSION} is substituted at build time by the actual


### PR DESCRIPTION
Apparently in #4788 the EPSG version was not written correctly

https://github.com/OSGeo/PROJ/pull/4788/changes#diff-7efcaee17a3e41e5440dc2ff9e962f20ad448a3ce5d7fff45a839846a85f37f8

- [x] Added clear title that can be used to generate release notes
