### PR TITLE
som: avoid cppcheck warning

### DIFF
--- a/src/projections/som.cpp
+++ b/src/projections/som.cpp
@@ -205,7 +205,7 @@ static PJ_LP som_e_inverse(PJ_XY xy, PJ *P) { /* Ellipsoidal, inverse */
 }
 
 static PJ *som_setup(PJ *P) {
-    double esc, ess, lam;
+    double esc, ess;
     struct pj_som_data *Q = static_cast<struct pj_som_data *>(P->opaque);
     Q->sa = sin(Q->alf);
     Q->ca = cos(Q->alf);
@@ -222,9 +222,9 @@ static PJ *som_setup(PJ *P) {
     Q->rlm2 = Q->rlm + M_TWOPI;
     Q->a2 = Q->a4 = Q->b = Q->c1 = Q->c3 = 0.;
     seraz0(0., 1., P);
-    for (lam = 9.; lam <= 81.0001; lam += 18.)
+    for (int lam = 9; lam <= 81; lam += 18)
         seraz0(lam, 4., P);
-    for (lam = 18; lam <= 72.0001; lam += 18.)
+    for (int lam = 18; lam <= 72; lam += 18)
         seraz0(lam, 2., P);
     seraz0(90., 1., P);
     Q->a2 /= 30.;


### PR DESCRIPTION
should fix https://github.com/OSGeo/PROJ/actions/runs/27851095459/job/82430145568
```
/home/runner/work/PROJ/PROJ/src/projections/som.cpp:227,style,knownConditionTrueFalse,Condition 'lam<=72.0001' is always false
```

This warning is a false positive but iteration condition based on floating-point variables is considered a bad practice.
