### PR TITLE
add proj_crs_is_dynamic(), and cs2cs: warn when source/destination CRS is dynamic, but no epoch is provided

### DIFF
--- a/scripts/reference_exported_symbols.txt
+++ b/scripts/reference_exported_symbols.txt
@@ -1036,6 +1036,7 @@ proj_crs_get_sub_crs
 proj_crs_has_point_motion_operation
 proj_crs_info_list_destroy
 proj_crs_is_derived
+proj_crs_is_dynamic
 proj_crs_promote_to_3D
 proj_cs_get_axis_count
 proj_cs_get_axis_info

--- a/src/apps/cs2cs.cpp
+++ b/src/apps/cs2cs.cpp
@@ -63,10 +63,12 @@ static PJ *transformation = nullptr;
 
 static bool srcIsLongLat = false;
 static double srcToRadians = 0.0;
+static bool srcIsDynamic = false;
 
 static bool destIsLongLat = false;
 static double destToRadians = 0.0;
 static bool destIsLatLong = false;
+static bool destIsDynamic = false;
 
 static int reversein = 0, /* != 0 reverse input arguments */
     reverseout = 0,       /* != 0 reverse output arguments */
@@ -153,8 +155,19 @@ static void process(FILE *fid)
         /* is forward verbatim from the input.                               */
         char *before_time = s;
         double t = strtod(s, &s);
-        if (s == before_time)
+        if (s == before_time) {
             t = HUGE_VAL;
+            if (srcIsDynamic) {
+                fprintf(
+                    stderr,
+                    "Input coordinates lack a coordinate epoch, whereas the "
+                    "source CRS is dynamic. Results might be inaccurate.\n");
+            } else if (destIsDynamic) {
+                fprintf(stderr, "Input coordinates lack a coordinate epoch, "
+                                "whereas the destination CRS is dynamic. "
+                                "Results might be inaccurate.\n");
+            }
+        }
         s = before_time;
 
         if (data.v == HUGE_VAL)
@@ -925,6 +938,8 @@ int main(int argc, char **argv) {
         }
         proj_destroy(src);
         src = srcMetadata;
+    } else if (proj_crs_is_dynamic(nullptr, src)) {
+        srcIsDynamic = true;
     }
 
     if (!targetEpoch.empty()) {
@@ -943,6 +958,8 @@ int main(int argc, char **argv) {
         }
         proj_destroy(dst);
         dst = dstMetadata;
+    } else if (proj_crs_is_dynamic(nullptr, dst)) {
+        destIsDynamic = true;
     }
 
     std::string authorityOption; /* keep this variable in this outer scope ! */

--- a/src/iso19111/c_api.cpp
+++ b/src/iso19111/c_api.cpp
@@ -2138,6 +2138,59 @@ int proj_crs_is_derived(PJ_CONTEXT *ctx, const PJ *crs) {
 
 // ---------------------------------------------------------------------------
 
+/** \brief Returns whether (at least one component of a) CRS has a dynamic
+ * reference frame
+ *
+ * @param ctx PROJ context, or NULL for default context
+ * @param crs Object of type CRS (must not be NULL)
+ * @return TRUE if the CRS is a dynamic CRS.
+ * @since 9.9
+ */
+int proj_crs_is_dynamic(PJ_CONTEXT *ctx, const PJ *crs) {
+    if (!crs) {
+        proj_context_errno_set(ctx, PROJ_ERR_OTHER_API_MISUSE);
+        proj_log_error(ctx, __FUNCTION__, "missing required input");
+        return false;
+    }
+    auto l_crs = dynamic_cast<const CRS *>(crs->iso_obj.get());
+    if (!l_crs) {
+        proj_log_error(ctx, __FUNCTION__, "Object is not a CRS");
+        return false;
+    }
+
+    const auto singleCRSIsDynamic = [](const CRS *singleCRS) {
+        if (auto geodCRS = singleCRS->extractGeodeticCRSRaw()) {
+            const auto &datum = geodCRS->datum();
+            if (dynamic_cast<const DynamicGeodeticReferenceFrame *>(
+                    datum.get()))
+                return true;
+        } else if (auto vertCRS =
+                       dynamic_cast<const VerticalCRS *>(singleCRS)) {
+            const auto &datum = vertCRS->datum();
+            if (dynamic_cast<const DynamicVerticalReferenceFrame *>(
+                    datum.get()))
+                return true;
+        }
+
+        return false;
+    };
+
+    if (dynamic_cast<const SingleCRS *>(l_crs)) {
+        return singleCRSIsDynamic(l_crs);
+    } else if (auto compoundCRS = dynamic_cast<const CompoundCRS *>(l_crs)) {
+        const auto components = compoundCRS->componentReferenceSystems();
+        for (const auto &comp : components) {
+            if (singleCRSIsDynamic(comp.get())) {
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+// ---------------------------------------------------------------------------
+
 /** \brief Get a CRS component from a CompoundCRS
  *
  * The returned object must be unreferenced with proj_destroy() after

--- a/src/proj.h
+++ b/src/proj.h
@@ -1432,6 +1432,8 @@ int PROJ_DLL proj_get_suggested_operation(PJ_CONTEXT *ctx,
 
 int PROJ_DLL proj_crs_is_derived(PJ_CONTEXT *ctx, const PJ *crs);
 
+int PROJ_DLL proj_crs_is_dynamic(PJ_CONTEXT *ctx, const PJ *crs);
+
 PJ PROJ_DLL *proj_crs_get_geodetic_crs(PJ_CONTEXT *ctx, const PJ *crs);
 
 PJ PROJ_DLL *proj_crs_get_horizontal_datum(PJ_CONTEXT *ctx, const PJ *crs);

--- a/test/cli/test_cs2cs_various.yaml
+++ b/test/cli/test_cs2cs_various.yaml
@@ -1087,7 +1087,9 @@ tests:
   in: |
     59.4967 -117.61748 329.396
     59.4967 -117.61748 329.396 1988
-  out: |
+  stderr: |
+    Input coordinates lack a coordinate epoch, whereas the source CRS is dynamic. Results might be inaccurate.
+  stdout: |
     59.4967 -117.61748 329.396	59.4967002	-117.6174799 329.3845529
     59.4967 -117.61748 329.396	59.4967002	-117.6174799 329.3845529 1988
 - comment: Check ob_tran with o_proj=longlat (#1525)
@@ -1129,12 +1131,16 @@ tests:
 - comment: Test effect of --authority (GH-2442) - use the EPSG:8076 operation
   args: ITRF96 ITRF2014
   in: 49 2
-  out: |
+  stderr: |
+    Input coordinates lack a coordinate epoch, whereas the source CRS is dynamic. Results might be inaccurate.
+  stdout: |
     49d0'0.002"N	2dE 0.018
 - comment: Test effect of --authority (GH-2442) - a no-op
   args: --authority PROJ ITRF96 ITRF2014
   in: 49 2
-  out: |
+  stderr: |
+    Input coordinates lack a coordinate epoch, whereas the source CRS is dynamic. Results might be inaccurate.
+  stdout: |
     49dN	2dE 0.000
 - comment: Test effect of --accuracy
   env:

--- a/test/unit/test_c_api.cpp
+++ b/test/unit/test_c_api.cpp
@@ -1069,11 +1069,10 @@ TEST_F(CApi, proj_create_from_database) {
         EXPECT_EQ(proj_dynamic_datum_get_frame_reference_epoch(m_ctxt, datum),
                   2005.0);
     }
-#ifdef no_more_dynamic_vertical_datum
     {
-        // Norway Normal Null 2000
+        // RH2000 height
         auto datum = proj_create_from_database(
-            m_ctxt, "EPSG", "1096", PJ_CATEGORY_DATUM, false, nullptr);
+            m_ctxt, "EPSG", "5208", PJ_CATEGORY_DATUM, false, nullptr);
         ASSERT_NE(datum, nullptr);
         ObjectKeeper keeper(datum);
         EXPECT_EQ(proj_get_type(datum),
@@ -1081,7 +1080,6 @@ TEST_F(CApi, proj_create_from_database) {
         EXPECT_EQ(proj_dynamic_datum_get_frame_reference_epoch(m_ctxt, datum),
                   2000.0);
     }
-#endif
     {
         auto op = proj_create_from_database(m_ctxt, "EPSG", "16031",
                                             PJ_CATEGORY_COORDINATE_OPERATION,
@@ -7726,6 +7724,71 @@ TEST_F(CApi, proj_crs_add_horizontal_derived_conversion) {
         EXPECT_EQ(proj_crs_add_horizontal_derived_conversion(
                       m_ctxt, "my derived crs", geog_crs, conv, cs),
                   nullptr);
+    }
+}
+
+// ---------------------------------------------------------------------------
+
+TEST_F(CApi, proj_crs_is_dynamic) {
+
+    {
+        // ITRF2020
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "9990",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_TRUE(proj_crs_is_dynamic(m_ctxt, crs));
+    }
+
+    {
+        // ETRS89
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "4258",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_FALSE(proj_crs_is_dynamic(m_ctxt, crs));
+    }
+
+    {
+        // RH2000 height
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "5613",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_TRUE(proj_crs_is_dynamic(m_ctxt, crs));
+    }
+
+    {
+        // EGM2008 height
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "3855",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_FALSE(proj_crs_is_dynamic(m_ctxt, crs));
+    }
+
+    {
+        // WGS 84 / Pseudo-Mercator +  EGM2008 geoid height
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "6871",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_FALSE(proj_crs_is_dynamic(m_ctxt, crs));
+    }
+
+    {
+        // ETRS89-SWE [SWEREF 99] + RH2000 height
+        auto crs = proj_create_from_database(m_ctxt, "EPSG", "5628",
+                                             PJ_CATEGORY_CRS, false, nullptr);
+        ASSERT_NE(crs, nullptr);
+        ObjectKeeper keeper(crs);
+
+        EXPECT_TRUE(proj_crs_is_dynamic(m_ctxt, crs));
     }
 }
 


### PR DESCRIPTION
Relates to https://lists.osgeo.org/pipermail/proj/2026-June/thread.html#12125 thread