### PR TITLE
[Draft] Do not use ITRF2020 as an intermediate for NAD83(2011) to NATRF2022

### DIFF
--- a/src/iso19111/factory.cpp
+++ b/src/iso19111/factory.cpp
@@ -7751,6 +7751,10 @@ AuthorityFactory::createFromCRSCodesWithIntermediates(
         starts_with(sourceCRS->nameStr(), "NAD83(CSRS)") &&
         starts_with(targetCRS->nameStr(), "NAD83(CSRS)");
 
+    const bool canUseDynamicIntermediate =
+        sourceCRS->isDynamic(/* considerWGS84AsDynamic = */ false) ||
+        targetCRS->isDynamic(/* considerWGS84AsDynamic = */ false);
+
     if (allowedIntermediateObjectType == ObjectType::GEOGRAPHIC_CRS) {
         const auto &sourceGeogCRS =
             dynamic_cast<const crs::GeographicCRS *>(sourceCRS.get());
@@ -7939,7 +7943,8 @@ AuthorityFactory::createFromCRSCodesWithIntermediates(
         res = filterOutSuperseded(std::move(res));
     }
 
-    const auto checkPivot = [ETRFtoETRF, NAD83_CSRS_to_NAD83_CSRS, &sourceCRS,
+    const auto checkPivot = [ETRFtoETRF, NAD83_CSRS_to_NAD83_CSRS,
+                             canUseDynamicIntermediate, &sourceCRS,
                              &targetCRS](const crs::CRSPtr &intermediateCRS) {
         // Make sure that ETRF2000 to ETRF2014 doesn't go through ITRF9x or
         // ITRF>2014
@@ -7967,6 +7972,11 @@ AuthorityFactory::createFromCRSCodesWithIntermediates(
         if (NAD83_CSRS_to_NAD83_CSRS && intermediateCRS &&
             (intermediateCRS->nameStr() == "NAD83" ||
              intermediateCRS->nameStr() == "WGS 84")) {
+            return false;
+        }
+
+        if (!canUseDynamicIntermediate &&
+            intermediateCRS->isDynamic(/* considerWGS84AsDynamic = */ false)) {
             return false;
         }
 
@@ -8325,6 +8335,10 @@ AuthorityFactory::createBetweenGeodeticCRSWithDatumBasedIntermediates(
         // link to a datum.
         return listTmp;
     }
+
+    const bool canUseDynamicIntermediate =
+        sourceCRS->isDynamic(/* considerWGS84AsDynamic = */ false) ||
+        targetCRS->isDynamic(/* considerWGS84AsDynamic = */ false);
 
     ListOfParams params;
     const auto BuildSQLPart = [this, NAD83_CSRS_to_NAD83_CSRS,
@@ -8689,6 +8703,11 @@ AuthorityFactory::createBetweenGeodeticCRSWithDatumBasedIntermediates(
         const auto &op2Source = op2NN->sourceCRS();
         const auto &op2Target = op2NN->targetCRS();
         if (!(op1Source && op1Target && op2Source && op2Target)) {
+            continue;
+        }
+
+        if (!canUseDynamicIntermediate &&
+            op1Target->isDynamic(/* considerWGS84AsDynamic = */ false)) {
             continue;
         }
 

--- a/test/unit/test_operationfactory.cpp
+++ b/test/unit/test_operationfactory.cpp
@@ -12220,6 +12220,38 @@ TEST(operation, createOperation_ETRS89_XXX_to_ETRS89_YYY_using_ETRF2000) {
 
 // ---------------------------------------------------------------------------
 
+TEST(operation, createOperation_NAD83_2011_to_NATRF2022_do_not_use_ITRF2020) {
+    auto dbContext = DatabaseContext::create();
+    auto authFactory = AuthorityFactory::create(dbContext, std::string());
+    auto authFactoryEPSG = AuthorityFactory::create(dbContext, "EPSG");
+    auto ctxt = CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+    ctxt->setSpatialCriterion(
+        CoordinateOperationContext::SpatialCriterion::PARTIAL_INTERSECTION);
+    ctxt->setGridAvailabilityUse(
+        CoordinateOperationContext::GridAvailabilityUse::
+            IGNORE_GRID_AVAILABILITY);
+    auto list = CoordinateOperationFactory::create()->createOperations(
+        // NAD83(2011)
+        authFactoryEPSG->createCoordinateReferenceSystem("6318"),
+        // NATRF2022e2020
+        authFactoryEPSG->createCoordinateReferenceSystem("10968"), ctxt);
+    ASSERT_EQ(list.size(), 2U);
+
+    EXPECT_STREQ(list[0]->nameStr().c_str(),
+                 "NAD83(2011) to WGS 84 (1) + "
+                 "Inverse of NATRF2022e2020 to WGS 84 (1)");
+    EXPECT_EQ(list[0]->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=noop");
+
+    EXPECT_STREQ(
+        list[1]->nameStr().c_str(),
+        "Ballpark geographic offset from NAD83(2011) to NATRF2022e2020");
+    EXPECT_EQ(list[1]->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=noop");
+}
+
+// ---------------------------------------------------------------------------
+
 TEST(operation, createOperation_time_dependent_helmert_directly_from_database) {
     auto dbContext = DatabaseContext::create();
     auto factory = AuthorityFactory::create(dbContext, "EPSG");


### PR DESCRIPTION
Was confirmed to be inappropriate by NOAA. They will publish grid based transformations for that.

The downside (benefit?) is that the generic logic that avoid that also avoids using the ETRF2000 intermediate for 'ETRS89-PRT [1995]' to 'ETRS89-ESP [ERGNSS]', which breaks one of our test, but perhaps for good reasons. Trying to clarify with EPSG what should be done for that one, given this is suggested by IOGP guidance note 7-7 para 6.3.4 " Relationship between national realizations using an operation pipeline through the hub"
