### PR TITLE
Optimization: replace iterative Aitoff inverse with closed-form inverse

### DIFF
--- a/docs/source/operations/projections/aitoff.rst
+++ b/docs/source/operations/projections/aitoff.rst
@@ -38,3 +38,35 @@ Parameters
 .. include:: ../options/x_0.rst
 
 .. include:: ../options/y_0.rst
+
+Mathematical definition
+################################################################################
+
+The forward projection is
+
+.. math::
+
+    \alpha &= \arccos \left( \cos\phi \, \cos\tfrac{\lambda}{2} \right)
+
+    x &= 2 \cos\phi \, \sin\tfrac{\lambda}{2} \; \frac{\alpha}{\sin\alpha}
+
+    y &= \sin\phi \; \frac{\alpha}{\sin\alpha}
+
+The Aitoff inverse has a closed form, so no iteration is required:
+
+.. math::
+
+    \alpha &= \sqrt{\left(\tfrac{x}{2}\right)^2 + y^2}
+
+    \phi &= \arcsin \frac{y \sin\alpha}{\alpha}
+
+    \lambda &= 2 \arctan2 \left( \tfrac{x}{2} \sin\alpha, \; \alpha \cos\alpha \right)
+
+Further reading
+################################################################################
+
+#. Kleffner, R. (2026). "Aitoff has a closed-form inverse" :cite:`Kleffner2026`,
+   which derives the inverse above and benchmarks it against the iterative
+   method.
+#. Kunimune, J. *Map-Projections* :cite:`KunimuneMapProjections`, an earlier
+   implementation using an equivalent structural decomposition.

--- a/docs/source/operations/projections/aitoff.rst
+++ b/docs/source/operations/projections/aitoff.rst
@@ -52,7 +52,9 @@ The forward projection is
 
     y &= \sin\phi \; \frac{\alpha}{\sin\alpha}
 
-The Aitoff inverse has a closed form, so no iteration is required:
+The inverse is the spherical azimuthal equidistant inverse of
+:cite:`Snyder1987`, p. 196, applied to :math:`(x/2, y)`, with the recovered
+longitude doubled:
 
 .. math::
 
@@ -65,8 +67,6 @@ The Aitoff inverse has a closed form, so no iteration is required:
 Further reading
 ################################################################################
 
-#. Kleffner, R. (2026). "Aitoff has a closed-form inverse" :cite:`Kleffner2026`,
-   which derives the inverse above and benchmarks it against the iterative
-   method.
-#. Kunimune, J. *Map-Projections* :cite:`KunimuneMapProjections`, an earlier
-   implementation using an equivalent structural decomposition.
+#. Kunimune, J. *Map-Projections* :cite:`KunimuneMapProjections`, which
+   implements the same inverse via a pre- and post-scaled azimuthal
+   equidistant inverse.

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -290,7 +290,7 @@
 @Misc{Kleffner2026,
   Title                    = {Aitoff has a closed-form inverse},
   Author                   = {Robert Kleffner},
-  HowPublished             = {Blog post, flatsphere.dev},
+  HowPublished             = {Blog post},
   Year                     = {2026},
 
   Url                      = {https://flatsphere.dev/blog/aitoff-has-closed-form-inverse/}

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -287,6 +287,15 @@
   Primaryclass             = {physics.geo-ph}
 }
 
+@Misc{Kleffner2026,
+  Title                    = {Aitoff has a closed-form inverse},
+  Author                   = {Robert Kleffner},
+  HowPublished             = {Blog post, flatsphere.dev},
+  Year                     = {2026},
+
+  Url                      = {https://flatsphere.dev/blog/aitoff-has-closed-form-inverse/}
+}
+
 @Article{Komsta2016,
   Title                    = {{ATPOL} geobotanical grid revisited -- a proposal of coordinate conversion algorithms},
   Author                   = {Łukasz Komsta},
@@ -306,6 +315,14 @@
   number =	 52,
   type =	 {New Series},
   doi =		 {10.2312/GFZ.b103-krueger28}
+}
+
+@Misc{KunimuneMapProjections,
+  Title                    = {Map-Projections},
+  Author                   = {Justin Kunimune},
+  HowPublished             = {Software, \url{https://github.com/jkunimune/Map-Projections}},
+
+  Url                      = {https://github.com/jkunimune/Map-Projections}
 }
 
 @InProceedings{LambersKolb2012,

--- a/docs/source/references.bib
+++ b/docs/source/references.bib
@@ -287,15 +287,6 @@
   Primaryclass             = {physics.geo-ph}
 }
 
-@Misc{Kleffner2026,
-  Title                    = {Aitoff has a closed-form inverse},
-  Author                   = {Robert Kleffner},
-  HowPublished             = {Blog post},
-  Year                     = {2026},
-
-  Url                      = {https://flatsphere.dev/blog/aitoff-has-closed-form-inverse/}
-}
-
 @Article{Komsta2016,
   Title                    = {{ATPOL} geobotanical grid revisited -- a proposal of coordinate conversion algorithms},
   Author                   = {Łukasz Komsta},
@@ -320,7 +311,7 @@
 @Misc{KunimuneMapProjections,
   Title                    = {Map-Projections},
   Author                   = {Justin Kunimune},
-  HowPublished             = {Software, \url{https://github.com/jkunimune/Map-Projections}},
+  HowPublished             = {Software},
 
   Url                      = {https://github.com/jkunimune/Map-Projections}
 }

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -541,6 +541,7 @@ Kavraisky
 Kavrayskiy
 Kilometer
 kinematically
+Kleffner
 kmi
 Kolb
 Komsta
@@ -551,6 +552,7 @@ krovak
 Krovak
 Krüger
 Kumul
+Kunimune
 Laborde
 labrd
 laea

--- a/docs/source/spelling_wordlist.txt
+++ b/docs/source/spelling_wordlist.txt
@@ -541,7 +541,6 @@ Kavraisky
 Kavrayskiy
 Kilometer
 kinematically
-Kleffner
 kmi
 Kolb
 Komsta

--- a/src/projections/aeqd.cpp
+++ b/src/projections/aeqd.cpp
@@ -125,49 +125,30 @@ static PJ_XY aeqd_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     struct pj_aeqd_data *Q = static_cast<struct pj_aeqd_data *>(P->opaque);
 
-    if (Q->mode == pj_aeqd_ns::EQUIT) {
-        const double cosphi = cos(lp.phi);
-        const double sinphi = sin(lp.phi);
-        const double coslam = cos(lp.lam);
-        const double sinlam = sin(lp.lam);
-
-        xy.y = cosphi * coslam;
-
-        if (fabs(fabs(xy.y) - 1.) < TOL) {
-            if (xy.y < 0.) {
-                proj_errno_set(
-                    P, PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN);
-                return xy;
-            } else
-                return aeqd_e_forward(lp, P);
-        } else {
-            xy.y = acos(xy.y);
-            xy.y /= sin(xy.y);
-            xy.x = xy.y * cosphi * sinlam;
-            xy.y *= sinphi;
-        }
-    } else if (Q->mode == pj_aeqd_ns::OBLIQ) {
+    if (Q->mode == pj_aeqd_ns::EQUIT || Q->mode == pj_aeqd_ns::OBLIQ) {
         const double cosphi = cos(lp.phi);
         const double sinphi = sin(lp.phi);
         const double coslam = cos(lp.lam);
         const double sinlam = sin(lp.lam);
         const double cosphi_x_coslam = cosphi * coslam;
 
-        xy.y = Q->sinph0 * sinphi + Q->cosph0 * cosphi_x_coslam;
+        /* c is the angular distance to (phi, lam). Deriving sin(c) with
+         * hypot and c with atan2 keeps the forward accurate near the
+         * antipode and near the center compared to using the customary
+         * acos formulation. */
+        const double cosc = Q->sinph0 * sinphi + Q->cosph0 * cosphi_x_coslam;
+        const double t = Q->cosph0 * sinphi - Q->sinph0 * cosphi_x_coslam;
+        const double sinc = hypot(cosphi * sinlam, t);
 
-        if (fabs(fabs(xy.y) - 1.) < TOL) {
-            if (xy.y < 0.) {
-                proj_errno_set(
-                    P, PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN);
-                return xy;
-            } else
-                return aeqd_e_forward(lp, P);
-        } else {
-            xy.y = acos(xy.y);
-            xy.y /= sin(xy.y);
-            xy.x = xy.y * cosphi * sinlam;
-            xy.y *= Q->cosph0 * sinphi - Q->sinph0 * cosphi_x_coslam;
+        if (cosc < TOL - 1.) {
+            /* the point opposite the projection center is undefined */
+            proj_errno_set(P, PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN);
+            return xy;
         }
+        /* c / sin(c), with limit 1 at the projection center */
+        const double k = sinc == 0 ? 1. : atan2(sinc, cosc) / sinc;
+        xy.x = k * cosphi * sinlam;
+        xy.y = k * t;
     } else {
         double coslam = cos(lp.lam);
         double sinlam = sin(lp.lam);

--- a/src/projections/aitoff.cpp
+++ b/src/projections/aitoff.cpp
@@ -5,6 +5,7 @@
  * Author:   Gerald Evenden (1995)
  *           Drazen Tutic, Lovro Gradiser (2015) - add inverse
  *           Thomas Knudsen (2016) - revise/add regression tests
+ *           Robert Kleffner (2026) - closed-form Aitoff inverse
  *
  ******************************************************************************
  * Copyright (c) 1995, Gerald Evenden
@@ -79,31 +80,83 @@ static PJ_XY aitoff_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
     return (xy);
 }
 
-/***********************************************************************************
+/******************************************************************************
  *
- * Inverse functions added by Drazen Tutic and Lovro Gradiser based on paper:
+ * Closed-form inverse of the Aitoff projection.
  *
- * I.Özbug Biklirici and Cengizhan Ipbüker. A General Algorithm for the Inverse
- * Transformation of Map Projections Using Jacobian Matrices. In Proceedings of
- *the Third International Symposium Mathematical & Computational Applications,
- * pages 175{182, Turkey, September 2002.
+ * Squaring and adding the forward equations cancels phi and lambda from the
+ * right-hand side and leaves the identity
  *
- * Expected accuracy is defined by EPSILON = 1e-12. Should be appropriate for
- * most applications of Aitoff and Winkel Tripel projections.
+ *     (x/2)^2 + y^2 = alpha^2,   alpha = acos(cos(phi) * cos(lambda/2)),
  *
- * Longitudes of 180W and 180E can be mixed in solution obtained.
+ * so alpha follows directly from (x, y) and the inverse needs no iteration:
  *
- * Inverse for Aitoff projection in poles is undefined, longitude value of 0 is
- *assumed.
+ *     alpha  = sqrt((x/2)^2 + y^2)
+ *     phi    = asin(y * sin(alpha) / alpha)
+ *     lambda = 2 * atan2((x/2) * sin(alpha), alpha * cos(alpha))
  *
- * Contact : dtutic at geof.hr
- * Date: 2015-02-16
+ * The atan2 form yields longitudes in [-pi, pi], which removes the 180W/180E
+ * ambiguity of the iterative solver, and the poles need no special case.
  *
- ************************************************************************************/
+ * See R. Kleffner, "Aitoff has a closed-form inverse" (2026),
+ * https://flatsphere.dev/blog/aitoff-has-closed-form-inverse/ , and the earlier
+ * structural closed form in J. Kunimune's Map-Projections,
+ * https://github.com/jkunimune/Map-Projections .
+ *
+ *****************************************************************************/
+
+/* Returns false, leaving *lp untouched, when (x, y) lies outside the bounding
+ * ellipse x^2 + 4*y^2 = pi^2 and therefore has no preimage on the sphere. */
+static bool aitoff_s_inverse_closed(PJ_XY xy, PJ *P, PJ_LP *lp) {
+    if (xy.x * xy.x + 4. * xy.y * xy.y > M_PI * M_PI)
+        return false;
+    const double half_x = 0.5 * xy.x;
+    const double alpha = sqrt(half_x * half_x + xy.y * xy.y);
+    if (alpha < 1e-9) {
+        /* limit at the origin: (phi, lambda) -> (y, x) as alpha -> 0 */
+        lp->phi = xy.y;
+        lp->lam = xy.x;
+        return true;
+    }
+    const double sin_alpha = sin(alpha);
+    lp->phi = aasin(P->ctx, xy.y * sin_alpha / alpha);
+    lp->lam = 2. * atan2(half_x * sin_alpha, alpha * cos(alpha));
+    return true;
+}
+
+/******************************************************************************
+ *
+ * Inverse of the Aitoff and Winkel Tripel projections.
+ *
+ * Aitoff uses the closed form above. Winkel Tripel is the average of the Aitoff
+ * and equirectangular projections and has no closed-form inverse, so it is
+ * solved with the Jacobian-matrix Newton-Raphson method of Bildirici and
+ * Ipbuker (2002), contributed by Drazen Tutic and Lovro Gradiser (2015). The
+ * iteration converges to EPSILON = 1e-12, appropriate for most applications of
+ * the projection.
+ *
+ * Reference:
+ *   I. O. Bildirici and C. Ipbuker (2002). A General Algorithm for the Inverse
+ *   Transformation of Map Projections Using Jacobian Matrices. Proceedings of
+ *   the Third International Symposium on Mathematical and Computational
+ *   Applications, pp. 175-182, Turkey.
+ *
+ * Contact: dtutic at geof.hr, 2015-02-16
+ *
+ *****************************************************************************/
 
 static PJ_LP aitoff_s_inverse(PJ_XY xy, PJ *P) { /* Spheroidal, inverse */
     PJ_LP lp = {0.0, 0.0};
     struct pj_aitoff_data *Q = static_cast<struct pj_aitoff_data *>(P->opaque);
+
+    if (Q->mode == pj_aitoff_ns::AITOFF) {
+        if (!aitoff_s_inverse_closed(xy, P, &lp)) {
+            proj_errno_set(P, PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN);
+            lp.lam = lp.phi = HUGE_VAL;
+        }
+        return lp;
+    }
+
     int iter, MAXITER = 10, round = 0, MAXROUND = 20;
     double EPSILON = 1e-12, D, C, f1, f2, f1p, f1l, f2p, f2l, dp, dl, sl, sp,
            cp, cl, x, y;
@@ -165,9 +218,6 @@ static PJ_LP aitoff_s_inverse(PJ_XY xy, PJ *P) { /* Spheroidal, inverse */
             lp.phi -=
                 2. * (lp.phi +
                       M_PI_2); /* correct if symmetrical solution for Aitoff */
-        if ((fabs(fabs(lp.phi) - M_PI_2) < EPSILON) &&
-            (Q->mode == pj_aitoff_ns::AITOFF))
-            lp.lam = 0.; /* if pole in Aitoff, return longitude of 0 */
 
         /* calculate x,y coordinates with solution obtained */
         if ((D = acos(cos(lp.phi) * cos(C = 0.5 * lp.lam))) !=

--- a/src/projections/aitoff.cpp
+++ b/src/projections/aitoff.cpp
@@ -66,19 +66,17 @@ static PJ_XY aitoff_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
     }
 #endif
     const double sin_half_lam = sin(0.5 * lp.lam);
-    const double cos_half_lam = cos(0.5 * lp.lam);
     const double sin_phi = sin(lp.phi);
     const double cos_phi = cos(lp.phi);
-    /* basic Aitoff; alpha is the angular distance to (phi, lam/2). Computing
-     * it with atan2 keeps relative accuracy near the origin, where acos of
-     * its cosine returns 0 for any alpha below ~1.5e-8. */
-    const double cos_alpha = cos_phi * cos_half_lam;
-    const double t = cos_phi * sin_half_lam;
-    const double sin_alpha = sqrt(t * t + sin_phi * sin_phi);
+    /* basic Aitoff; computing it with atan2 (instead of standard acos)
+     * keeps relative accuracy near the origin. */
+    const double sin_alpha = hypot(cos_phi * sin_half_lam, sin_phi);
     /* alpha / sin(alpha), with limit 1 at the origin */
     const double A =
-        sin_alpha == 0 ? 1. : atan2(sin_alpha, cos_alpha) / sin_alpha;
-    xy.x = 2. * t * A;
+        sin_alpha == 0
+            ? 1.
+            : atan2(sin_alpha, cos_phi * cos(0.5 * lp.lam)) / sin_alpha;
+    xy.x = 2. * cos_phi * sin_half_lam * A;
     xy.y = sin_phi * A;
     if (Q->mode == pj_aitoff_ns::WINKEL_TRIPEL) {
         xy.x = (xy.x + lp.lam * Q->cosphi1) * 0.5;

--- a/src/projections/aitoff.cpp
+++ b/src/projections/aitoff.cpp
@@ -56,7 +56,6 @@ FORWARD(aitoff_s_forward); /* spheroid */
 static PJ_XY aitoff_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
     PJ_XY xy = {0.0, 0.0};
     struct pj_aitoff_data *Q = static_cast<struct pj_aitoff_data *>(P->opaque);
-    double c, d;
 
 #if 0
     // Likely domain of validity for wintri in +over mode. Should be confirmed
@@ -66,13 +65,21 @@ static PJ_XY aitoff_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
         return xy;
     }
 #endif
-    c = 0.5 * lp.lam;
-    d = acos(cos(lp.phi) * cos(c));
-    if (d != 0.0) { /* basic Aitoff */
-        xy.x = 2. * d * cos(lp.phi) * sin(c) * (xy.y = 1. / sin(d));
-        xy.y *= d * sin(lp.phi);
-    } else
-        xy.x = xy.y = 0.;
+    const double sin_half_lam = sin(0.5 * lp.lam);
+    const double cos_half_lam = cos(0.5 * lp.lam);
+    const double sin_phi = sin(lp.phi);
+    const double cos_phi = cos(lp.phi);
+    /* basic Aitoff; alpha is the angular distance to (phi, lam/2). Computing
+     * it with atan2 keeps relative accuracy near the origin, where acos of
+     * its cosine returns 0 for any alpha below ~1.5e-8. */
+    const double cos_alpha = cos_phi * cos_half_lam;
+    const double t = cos_phi * sin_half_lam;
+    const double sin_alpha = sqrt(t * t + sin_phi * sin_phi);
+    /* alpha / sin(alpha), with limit 1 at the origin */
+    const double A =
+        sin_alpha == 0 ? 1. : atan2(sin_alpha, cos_alpha) / sin_alpha;
+    xy.x = 2. * t * A;
+    xy.y = sin_phi * A;
     if (Q->mode == pj_aitoff_ns::WINKEL_TRIPEL) {
         xy.x = (xy.x + lp.lam * Q->cosphi1) * 0.5;
         xy.y = (xy.y + lp.phi) * 0.5;
@@ -82,45 +89,37 @@ static PJ_XY aitoff_s_forward(PJ_LP lp, PJ *P) { /* Spheroidal, forward */
 
 /******************************************************************************
  *
- * Closed-form inverse of the Aitoff projection.
+ * Closed-form inverse of the Aitoff projection. Short form equations are:
  *
- * Squaring and adding the forward equations cancels phi and lambda from the
- * right-hand side and leaves the identity
- *
- *     (x/2)^2 + y^2 = alpha^2,   alpha = acos(cos(phi) * cos(lambda/2)),
- *
- * so alpha follows directly from (x, y) and the inverse needs no iteration:
- *
- *     alpha  = sqrt((x/2)^2 + y^2)
+ *     alpha  = hypot(x/2, y)      (angular distance to (phi, lambda/2))
  *     phi    = asin(y * sin(alpha) / alpha)
  *     lambda = 2 * atan2((x/2) * sin(alpha), alpha * cos(alpha))
  *
- * The atan2 form yields longitudes in [-pi, pi], which removes the 180W/180E
- * ambiguity of the iterative solver, and the poles need no special case.
+ * atan2 places lambda/2 in (-pi, pi]. The domain of the inverse is therefore
+ * the whole ellipse x^2 + 4*y^2 <= (2*pi)^2, on which the sphere is double
+ * covered; longitudes beyond +/-pi are returned only with +over. The poles
+ * need no special case.
  *
- * See R. Kleffner, "Aitoff has a closed-form inverse" (2026),
- * https://flatsphere.dev/blog/aitoff-has-closed-form-inverse/ , and the earlier
- * structural closed form in J. Kunimune's Map-Projections,
- * https://github.com/jkunimune/Map-Projections .
+ * Reference:
+ *   J. P. Snyder (1987). Map Projections -- A Working Manual. USGS
+ *   Professional Paper 1395, pp. 195-197.
  *
  *****************************************************************************/
 
-/* Returns false, leaving *lp untouched, when (x, y) lies outside the bounding
- * ellipse x^2 + 4*y^2 = pi^2 and therefore has no preimage on the sphere. */
-static bool aitoff_s_inverse_closed(PJ_XY xy, PJ *P, PJ_LP *lp) {
-    if (xy.x * xy.x + 4. * xy.y * xy.y > M_PI * M_PI)
-        return false;
+/* Returns false, leaving *lp untouched, when (x, y) is outside the ellipse
+ * x^2 + 4*y^2 = (2*pi)^2 and so has no preimage. */
+static bool aitoff_s_inverse_closed(PJ_XY xy, PJ_LP *lp) {
     const double half_x = 0.5 * xy.x;
-    const double alpha = sqrt(half_x * half_x + xy.y * xy.y);
-    if (alpha < 1e-9) {
-        /* limit at the origin: (phi, lambda) -> (y, x) as alpha -> 0 */
-        lp->phi = xy.y;
-        lp->lam = xy.x;
-        return true;
-    }
+    const double alpha = hypot(half_x, xy.y);
     const double sin_alpha = sin(alpha);
-    lp->phi = aasin(P->ctx, xy.y * sin_alpha / alpha);
-    lp->lam = 2. * atan2(half_x * sin_alpha, alpha * cos(alpha));
+    const double cos_alpha = cos(alpha);
+    /* Testing sin_alpha is needed because with long doubles sin(M_PI) < 0. */
+    if (alpha > M_PI || sin_alpha < 0)
+        return false;
+    /* The asin argument is guaranteed to lie in [-1, 1]: hypot(a, b) >= |b|
+     * and 0 <= sin_alpha <= 1. */
+    lp->phi = alpha == 0.0 ? xy.y : asin((xy.y / alpha) * sin_alpha);
+    lp->lam = 2. * atan2(half_x * sin_alpha, alpha * cos_alpha);
     return true;
 }
 
@@ -128,12 +127,11 @@ static bool aitoff_s_inverse_closed(PJ_XY xy, PJ *P, PJ_LP *lp) {
  *
  * Inverse of the Aitoff and Winkel Tripel projections.
  *
- * Aitoff uses the closed form above. Winkel Tripel is the average of the Aitoff
- * and equirectangular projections and has no closed-form inverse, so it is
- * solved with the Jacobian-matrix Newton-Raphson method of Bildirici and
- * Ipbuker (2002), contributed by Drazen Tutic and Lovro Gradiser (2015). The
- * iteration converges to EPSILON = 1e-12, appropriate for most applications of
- * the projection.
+ * Aitoff uses the closed form above. Winkel Tripel, the mean of the Aitoff and
+ * equirectangular projections, has no known closed-form inverse; it is inverted
+ * with the Newton-Raphson method of Bildirici and Ipbuker (2002), added by
+ * Drazen Tutic and Lovro Gradiser (2015). Expected accuracy is defined by
+ * EPSILON = 1e-12, appropriate for most applications of the projection.
  *
  * Reference:
  *   I. O. Bildirici and C. Ipbuker (2002). A General Algorithm for the Inverse
@@ -150,7 +148,7 @@ static PJ_LP aitoff_s_inverse(PJ_XY xy, PJ *P) { /* Spheroidal, inverse */
     struct pj_aitoff_data *Q = static_cast<struct pj_aitoff_data *>(P->opaque);
 
     if (Q->mode == pj_aitoff_ns::AITOFF) {
-        if (!aitoff_s_inverse_closed(xy, P, &lp)) {
+        if (!aitoff_s_inverse_closed(xy, &lp)) {
             proj_errno_set(P, PROJ_ERR_COORD_TRANSFM_OUTSIDE_PROJECTION_DOMAIN);
             lp.lam = lp.phi = HUGE_VAL;
         }

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -480,6 +480,34 @@ expect  -0.001790493 0.000895247
 accept  -200 -100
 expect  -0.001790493 -0.000895247
 
+# Closed-form inverse: explicit interior points (projected x,y from the forward)
+direction inverse
+accept  2783578.563317653 4512225.413913478
+expect  30 40
+accept  -8014380.291396681 2395844.852480214
+expect  -75 20
+accept  8983838.624520272 -8054689.356660859
+expect  150 -60
+
+# Points outside the bounding ellipse x^2 + 4 y^2 = (pi R)^2 have no preimage
+accept  40000000 0
+expect  failure errno coord_transfm_outside_projection_domain
+
+# Round-trip stability across the domain, including the poles and antimeridian
+direction forward
+accept  30 40
+roundtrip 100
+accept  -75 20
+roundtrip 100
+accept  150 -60
+roundtrip 100
+accept  179 89
+roundtrip 100
+accept  0 90
+roundtrip 100
+accept  180 0
+roundtrip 100
+
 
 ===============================================================================
 # Mod. Stereographic of Alaska

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -133,6 +133,34 @@ accept  180     0
 expect  failure errno coord_transfm_outside_projection_domain
 
 -------------------------------------------------------------------------------
+# Spherical accuracy near the projection center and near the antipode, where a
+# forward using acos can be off by hundreds of metres just outside the antipodal
+# cutoff. Expected values cross-checked against spherical geodesics.
+-------------------------------------------------------------------------------
+operation +proj=aeqd +R=6400000 +lat_0=0
+-------------------------------------------------------------------------------
+tolerance 0.1 mm
+accept  0.000011459155902616 0.000005729577951308
+expect  1.28 0.64
+roundtrip 100
+accept  179.99994270422047 0
+expect  20106186.5829747 0
+roundtrip 100
+
+-------------------------------------------------------------------------------
+operation +proj=aeqd +R=6400000 +lat_0=40
+-------------------------------------------------------------------------------
+tolerance 0.1 mm
+accept  0.000011459155902616 40.000005729577951
+expect  0.980536805 0.640000063
+accept  30 60
+expect  1662323.920096250 2560502.459379668
+roundtrip 100
+accept  179.99 -39.99
+expect  12227589.751270 15958961.844794
+roundtrip 100
+
+-------------------------------------------------------------------------------
 # Test equatorial aspect of the ellipsoidal azimuthal equidistant. Test data from
 # Snyder pp. 196-197, table 30.
 -------------------------------------------------------------------------------

--- a/test/gie/builtins.gie
+++ b/test/gie/builtins.gie
@@ -470,6 +470,10 @@ expect  -223379.458811696 111706.742883853
 accept  -2 -1
 expect  -223379.458811696 -111706.742883853
 
+# About 0.1 m from the origin; an acos-based forward collapses this to 0,0
+accept  0.0000011459155903 0.0000005729577951
+expect  0.128 0.064
+
 direction inverse
 accept  200 100
 expect  0.001790493 0.000895247
@@ -480,7 +484,7 @@ expect  -0.001790493 0.000895247
 accept  -200 -100
 expect  -0.001790493 -0.000895247
 
-# Closed-form inverse: explicit interior points (projected x,y from the forward)
+# Inverse at interior points; input x/y computed with the forward projection
 direction inverse
 accept  2783578.563317653 4512225.413913478
 expect  30 40
@@ -489,11 +493,15 @@ expect  -75 20
 accept  8983838.624520272 -8054689.356660859
 expect  150 -60
 
-# Points outside the bounding ellipse x^2 + 4 y^2 = (pi R)^2 have no preimage
-accept  40000000 0
+# The origin
+accept  0 0
+expect  0 0
+
+# Points outside the bounding ellipse x^2 + 4 y^2 = (2 pi R)^2 have no preimage
+accept  41000000 0
 expect  failure errno coord_transfm_outside_projection_domain
 
-# Round-trip stability across the domain, including the poles and antimeridian
+# Round trips, including at the poles and the antimeridian
 direction forward
 accept  30 40
 roundtrip 100
@@ -506,6 +514,24 @@ roundtrip 100
 accept  0 90
 roundtrip 100
 accept  180 0
+roundtrip 100
+
+-------------------------------------------------------------------------------
+operation +proj=aitoff   +R=6400000   +over
+-------------------------------------------------------------------------------
+tolerance 0.1 mm
+# With +over, the domain extends to the full ellipse with semiaxes 2 pi R and
+# pi R, on which the sphere is double covered
+direction inverse
+accept  23003371.041774839 6193033.156583068
+expect  240 25
+accept  -15044905.474035570 -12624174.634360289
+expect  -300 -40
+
+direction forward
+accept  240 25
+roundtrip 100
+accept  -300 -40
 roundtrip 100
 
 
@@ -8310,6 +8336,10 @@ accept  -2 1
 expect  -223390.801533485 111703.907505745
 accept  -2 -1
 expect  -223390.801533485 -111703.907505745
+
+# About 0.1 m from the origin; an acos-based forward loses the Aitoff term
+accept  0.0000011459155903 0.0000005729577951
+expect  0.128 0.064
 
 direction inverse
 accept  200 100


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
- [x] Tests added
- [x] Added clear title that can be used to generate release notes
- [x] Fully documented, including updating `docs/source/*.rst` for new API

## Justification

In a side project I've been working on, I uncovered the (*already-known*) existence of an exact closed-form inverse for the Aitoff projection (in part thanks to an AI agent I was having help build the project). It's fairly straightforward to derive: squaring and adding the forward equations eliminates φ and λ from the right-hand side with some trig identities, leaving the identity (x/2)² + y² = α². Then α in terms of x and y, and thus derivations of φ and λ, follow directly:

    α = √((x/2)² + y²)
    φ = asin(y·sin α / α)
    λ = 2·atan2((x/2)·sin α, α·cos α)

This replaces the nested Newton–Raphson inverse in use since 2015. The closed form matches the iterative result to machine precision, is noticeably faster, needs no special case at the poles, and returns longitudes in [−π, π] by construction.

Winkel Tripel shares this file and unfortunately has no closed-form inverse I'm aware of, despite my attempts. I also attempted seeding the Winkel Tripel iteration with the closed-form inverse, but this ended up hampering performance a bit since the iteration converges so quickly in most cases. So, its Newton–Raphson solver and verification loop are retained, and its results are unchanged.

## Correctness

- Every existing Aitoff and Winkel Tripel gie case passes unchanged.
- Added Aitoff round-trip tests over the interior, poles, and anti-meridian, as well as explicit interior inverse tests and a domain-rejection case.

## Performance

Measured on an M2 MacBook Air with `test/benchmark/bench_proj_trans`, inverting via a pipeline:

    bench_proj_trans -l 5000000 --noise-x 2000000 --noise-y 1000000 \
      -p "+proj=pipeline +step +inv +proj=aitoff +R=6400000" 5000000 2500000

~1.8 → ~11 M coordinates/s = ~6× speedup end-to-end through proj_trans.

## References

- Inverse formulas: J. P. Snyder (1987). *Map Projections — A Working Manual*.
  USGS Professional Paper 1395, pp. 195–197. https://doi.org/10.3133/pp1395
- Prior implementation of the same inverse (via a pre- and post-scaled
  azimuthal equidistant inverse): Justin Kunimune, *Map-Projections*,
  https://github.com/jkunimune/Map-Projections