### PR TITLE
Implement EPSG:9666 and EPSG:1049 seismic bin grid operation methods

### DIFF
--- a/docs/source/operations/transformations/affine.rst
+++ b/docs/source/operations/transformations/affine.rst
@@ -61,25 +61,38 @@ This can be used to implement:
     * xoff to :math:`I_0 - (s11 \times E_0 + s12 \times N_0)`
     * yoff to :math:`J_0 - (s21 \times E_0 + s22 \times N_0)`
 
-  where:
+  where, naming each quantity after the EPSG parameter that carries it:
 
-    * :math:`s_I = Inc_I / (k \times M_I)` and :math:`s_J = Inc_J / (k \times M_J)`
-      are the number of bin grid units per map grid unit along the I and J axes,
-      with :math:`M_I` and :math:`M_J` the bin widths on the I and J axes,
-      :math:`Inc_I` and :math:`Inc_J` the bin node increments on the I and J
-      axes, and :math:`k` the scale factor of the bin grid.
-    * :math:`I_0` and :math:`J_0` are the bin grid coordinates of the origin
-      point of the bin grid, and :math:`E_0` and :math:`N_0` its easting and
-      northing in the map grid.
-    * :math:`\theta` is the map grid bearing of the bin grid J-axis, clockwise
-      being positive.
+    * :math:`I_0` and :math:`J_0` are "Bin grid origin I" (EPSG:8733) and
+      "Bin grid origin J" (EPSG:8734), the bin grid coordinates of the origin
+      point of the bin grid.
+    * :math:`E_0` and :math:`N_0` are "Bin grid origin Easting" (EPSG:8735) and
+      "Bin grid origin Northing" (EPSG:8736), the map grid coordinates of that
+      same origin point.
+    * :math:`SF` is "Scale factor of bin grid" (EPSG:8737), that is the point
+      scale factor of the map grid at a chosen reference point.
+    * :math:`M_I` and :math:`M_J` are "Bin width on I-axis" (EPSG:8738) and
+      "Bin width on J-axis" (EPSG:8739).
+    * :math:`Inc_I` and :math:`Inc_J` are "Bin node increment on I-axis"
+      (EPSG:8741) and "Bin node increment on J-axis" (EPSG:8742).
+    * :math:`\theta` is "Map grid bearing of bin grid J-axis" (EPSG:8740),
+      clockwise being positive.
+    * :math:`s_I = Inc_I / (SF \times M_I)` and
+      :math:`s_J = Inc_J / (SF \times M_J)` are the resulting number of bin
+      grid units per map grid unit, along the I and J axes respectively.
     * the upper sign of :math:`\pm` and :math:`\mp` applies to the
       right-handed method 9666 (I = J+90°) and the lower one to the
       left-handed method 1049 (I = J-90°).
 
-  :math:`M_I`, :math:`M_J`, :math:`E_0` and :math:`N_0` must all be expressed
+  :math:`E_0`, :math:`N_0`, :math:`M_I` and :math:`M_J` must all be expressed
   in the same linear unit as the easting and northing fed to the affine
   operation.
+
+  The resulting bin numbers are not rounded, so that the operation remains
+  exactly invertible. EPSG defines bin grid coordinate systems that accept real
+  values as well as ones restricted to integer values, so whether bin numbers
+  are whole values is a property of the bin grid coordinate system, not of
+  these methods.
 
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++

--- a/docs/source/operations/transformations/affine.rst
+++ b/docs/source/operations/transformations/affine.rst
@@ -49,6 +49,38 @@ This can be used to implement:
       be rotated to coincide with the axes of the target CRS, counter-clockwise
       being positive
 
+- EPSG "P6 I=J+90 seismic bin grid coordinate operation" of code 9666 and
+  "P6 I=J-90 seismic bin grid coordinate operation" of code 1049, which convert
+  from the easting/northing of a map grid to the I/J bin numbers of a seismic
+  bin grid, by setting:
+
+    * s11 to :math:`\pm s_I \cos \theta`
+    * s12 to :math:`\mp s_I \sin \theta`
+    * s21 to :math:`s_J \sin \theta`
+    * s22 to :math:`s_J \cos \theta`
+    * xoff to :math:`I_0 - (s11 \times E_0 + s12 \times N_0)`
+    * yoff to :math:`J_0 - (s21 \times E_0 + s22 \times N_0)`
+
+  where:
+
+    * :math:`s_I = Inc_I / (k \times M_I)` and :math:`s_J = Inc_J / (k \times M_J)`
+      are the number of bin grid units per map grid unit along the I and J axes,
+      with :math:`M_I` and :math:`M_J` the bin widths on the I and J axes,
+      :math:`Inc_I` and :math:`Inc_J` the bin node increments on the I and J
+      axes, and :math:`k` the scale factor of the bin grid.
+    * :math:`I_0` and :math:`J_0` are the bin grid coordinates of the origin
+      point of the bin grid, and :math:`E_0` and :math:`N_0` its easting and
+      northing in the map grid.
+    * :math:`\theta` is the map grid bearing of the bin grid J-axis, clockwise
+      being positive.
+    * the upper sign of :math:`\pm` and :math:`\mp` applies to the
+      right-handed method 9666 (I = J+90°) and the lower one to the
+      left-handed method 1049 (I = J-90°).
+
+  :math:`M_I`, :math:`M_J`, :math:`E_0` and :math:`N_0` must all be expressed
+  in the same linear unit as the easting and northing fed to the affine
+  operation.
+
 Examples
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 

--- a/src/iso19111/operation/conversion.cpp
+++ b/src/iso19111/operation/conversion.cpp
@@ -3778,6 +3778,11 @@ void Conversion::_exportToPROJString(
         methodEPSGCode == EPSG_CODE_METHOD_AFFINE_PARAMETRIC_TRANSFORMATION;
     const bool isSimilarity =
         methodEPSGCode == EPSG_CODE_METHOD_SIMILARITY_TRANSFORMATION;
+    // Those methods deal themselves with the unit and axis order of the map
+    // grid they are based on, and emit bin numbers, which are unit-less.
+    const bool isSeismicBinGrid =
+        methodEPSGCode == EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90 ||
+        methodEPSGCode == EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90;
     const bool isGeographicGeocentric =
         methodEPSGCode == EPSG_CODE_METHOD_GEOGRAPHIC_GEOCENTRIC;
     const bool isGeographicOffsets =
@@ -3788,8 +3793,9 @@ void Conversion::_exportToPROJString(
         methodEPSGCode == EPSG_CODE_METHOD_HEIGHT_DEPTH_REVERSAL;
     const bool applySourceCRSModifiers =
         !isZUnitConversion && !isAffineParametric && !isSimilarity &&
-        !isAxisOrderReversal(methodEPSGCode) && !isGeographicGeocentric &&
-        !isGeographicOffsets && !isHeightDepthReversal;
+        !isSeismicBinGrid && !isAxisOrderReversal(methodEPSGCode) &&
+        !isGeographicGeocentric && !isGeographicOffsets &&
+        !isHeightDepthReversal;
     bool applyTargetCRSModifiers = applySourceCRSModifiers;
 
     if (formatter->getCRSExport()) {

--- a/src/iso19111/operation/parammappings.cpp
+++ b/src/iso19111/operation/parammappings.cpp
@@ -1024,6 +1024,8 @@ const struct MethodNameCode methodNameCodesList[] = {
     METHOD_NAME_CODE(LONGITUDE_ROTATION),
     METHOD_NAME_CODE(AFFINE_PARAMETRIC_TRANSFORMATION),
     METHOD_NAME_CODE(SIMILARITY_TRANSFORMATION),
+    METHOD_NAME_CODE(SEISMIC_BIN_GRID_I_EQ_J_PLUS_90),
+    METHOD_NAME_CODE(SEISMIC_BIN_GRID_I_EQ_J_MINUS_90),
     METHOD_NAME_CODE(COORDINATE_FRAME_GEOCENTRIC),
     METHOD_NAME_CODE(COORDINATE_FRAME_FULL_MATRIX_GEOCENTRIC),
     METHOD_NAME_CODE(COORDINATE_FRAME_GEOGRAPHIC_2D),
@@ -1177,6 +1179,16 @@ const struct ParamNameCode gParamNameCodes[] = {
     PARAM_NAME_CODE(ORDINATE_1_EVAL_POINT),
     PARAM_NAME_CODE(ORDINATE_2_EVAL_POINT),
     PARAM_NAME_CODE(ORDINATE_3_EVAL_POINT),
+    PARAM_NAME_CODE(BIN_GRID_ORIGIN_I),
+    PARAM_NAME_CODE(BIN_GRID_ORIGIN_J),
+    PARAM_NAME_CODE(BIN_GRID_ORIGIN_EASTING),
+    PARAM_NAME_CODE(BIN_GRID_ORIGIN_NORTHING),
+    PARAM_NAME_CODE(SCALE_FACTOR_OF_BIN_GRID),
+    PARAM_NAME_CODE(BIN_WIDTH_ON_I_AXIS),
+    PARAM_NAME_CODE(BIN_WIDTH_ON_J_AXIS),
+    PARAM_NAME_CODE(MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS),
+    PARAM_NAME_CODE(BIN_NODE_INCREMENT_ON_I_AXIS),
+    PARAM_NAME_CODE(BIN_NODE_INCREMENT_ON_J_AXIS),
     PARAM_NAME_CODE(GEOCENTRIC_TRANSLATION_FILE),
     PARAM_NAME_CODE(INCLINATION_IN_LATITUDE),
     PARAM_NAME_CODE(INCLINATION_IN_LONGITUDE),
@@ -1289,6 +1301,69 @@ static const ParamMapping paramRotationAngleOfSourceCRSAxes = {
 static const ParamMapping *const paramsSimilarityTransformation[] = {
     &paramOrdinate1EvalPointTargetCRS, &paramOrdinate2EvalPointTargetCRS,
     &paramScaleFactorForSourceCRSAxes, &paramRotationAngleOfSourceCRSAxes,
+    nullptr};
+
+static const ParamMapping paramBinGridOriginI = {
+    EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_I,
+    EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_I, nullptr,
+    common::UnitOfMeasure::Type::SCALE, nullptr};
+
+static const ParamMapping paramBinGridOriginJ = {
+    EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_J,
+    EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_J, nullptr,
+    common::UnitOfMeasure::Type::SCALE, nullptr};
+
+static const ParamMapping paramBinGridOriginEasting = {
+    EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_EASTING,
+    EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_EASTING, nullptr,
+    common::UnitOfMeasure::Type::LINEAR, nullptr};
+
+static const ParamMapping paramBinGridOriginNorthing = {
+    EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_NORTHING,
+    EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_NORTHING, nullptr,
+    common::UnitOfMeasure::Type::LINEAR, nullptr};
+
+static const ParamMapping paramScaleFactorOfBinGrid = {
+    EPSG_NAME_PARAMETER_SCALE_FACTOR_OF_BIN_GRID,
+    EPSG_CODE_PARAMETER_SCALE_FACTOR_OF_BIN_GRID, nullptr,
+    common::UnitOfMeasure::Type::SCALE, nullptr};
+
+static const ParamMapping paramBinWidthOnIAxis = {
+    EPSG_NAME_PARAMETER_BIN_WIDTH_ON_I_AXIS,
+    EPSG_CODE_PARAMETER_BIN_WIDTH_ON_I_AXIS, nullptr,
+    common::UnitOfMeasure::Type::LINEAR, nullptr};
+
+static const ParamMapping paramBinWidthOnJAxis = {
+    EPSG_NAME_PARAMETER_BIN_WIDTH_ON_J_AXIS,
+    EPSG_CODE_PARAMETER_BIN_WIDTH_ON_J_AXIS, nullptr,
+    common::UnitOfMeasure::Type::LINEAR, nullptr};
+
+static const ParamMapping paramMapGridBearingOfBinGridJAxis = {
+    EPSG_NAME_PARAMETER_MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS,
+    EPSG_CODE_PARAMETER_MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS, nullptr,
+    common::UnitOfMeasure::Type::ANGULAR, nullptr};
+
+static const ParamMapping paramBinNodeIncrementOnIAxis = {
+    EPSG_NAME_PARAMETER_BIN_NODE_INCREMENT_ON_I_AXIS,
+    EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_I_AXIS, nullptr,
+    common::UnitOfMeasure::Type::SCALE, nullptr};
+
+static const ParamMapping paramBinNodeIncrementOnJAxis = {
+    EPSG_NAME_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS,
+    EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS, nullptr,
+    common::UnitOfMeasure::Type::SCALE, nullptr};
+
+static const ParamMapping *const paramsSeismicBinGrid[] = {
+    &paramBinGridOriginI,
+    &paramBinGridOriginJ,
+    &paramBinGridOriginEasting,
+    &paramBinGridOriginNorthing,
+    &paramScaleFactorOfBinGrid,
+    &paramBinWidthOnIAxis,
+    &paramBinWidthOnJAxis,
+    &paramMapGridBearingOfBinGridJAxis,
+    &paramBinNodeIncrementOnIAxis,
+    &paramBinNodeIncrementOnJAxis,
     nullptr};
 
 static const ParamMapping paramXTranslation = {
@@ -1606,6 +1681,14 @@ static const MethodMapping gOtherMethodMappings[] = {
     {EPSG_NAME_METHOD_SIMILARITY_TRANSFORMATION,
      EPSG_CODE_METHOD_SIMILARITY_TRANSFORMATION, nullptr, nullptr, nullptr,
      paramsSimilarityTransformation},
+
+    {EPSG_NAME_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90,
+     EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90, nullptr, nullptr,
+     nullptr, paramsSeismicBinGrid},
+
+    {EPSG_NAME_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90,
+     EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90, nullptr, nullptr,
+     nullptr, paramsSeismicBinGrid},
 
     {PROJ_WKT2_NAME_METHOD_POLE_ROTATION_GRIB_CONVENTION, 0, nullptr, nullptr,
      nullptr, paramsPoleRotationGRIBConvention},

--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -3386,6 +3386,90 @@ bool SingleOperation::exportToPROJStringGeneric(
         return true;
     }
 
+    if (methodEPSGCode == EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90 ||
+        methodEPSGCode == EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90) {
+        // EPSG guidance note 7-2, section 2.4.3.3.
+        // Note that EPSG orders those operations from the map grid (source
+        // CRS) to the bin grid (target CRS), whereas the formulas of the
+        // guidance note are written in the opposite direction. Consequently
+        // what is implemented below is the reverse formula of the guidance
+        // note.
+        const double I0 =
+            parameterValueNumericAsSI(EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_I);
+        const double J0 =
+            parameterValueNumericAsSI(EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_J);
+        const double E0 =
+            parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_EASTING,
+                                  common::UnitOfMeasure::METRE);
+        const double N0 =
+            parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_NORTHING,
+                                  common::UnitOfMeasure::METRE);
+        const double k = parameterValueNumericAsSI(
+            EPSG_CODE_PARAMETER_SCALE_FACTOR_OF_BIN_GRID);
+        const double binWidthI =
+            parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_WIDTH_ON_I_AXIS,
+                                  common::UnitOfMeasure::METRE);
+        const double binWidthJ =
+            parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_WIDTH_ON_J_AXIS,
+                                  common::UnitOfMeasure::METRE);
+        const double theta = parameterValueNumeric(
+            EPSG_CODE_PARAMETER_MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS,
+            common::UnitOfMeasure::RADIAN);
+        const double incI = parameterValueNumericAsSI(
+            EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_I_AXIS);
+        const double incJ = parameterValueNumericAsSI(
+            EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS);
+
+        if (k == 0.0 || binWidthI == 0.0 || binWidthJ == 0.0) {
+            throw io::FormattingException(
+                "Invalid seismic bin grid operation: the scale factor of the "
+                "bin grid and the bin widths must be non-zero");
+        }
+
+        // Number of bin grid units per map grid unit, along each bin grid axis.
+        const double scaleI = incI / (k * binWidthI);
+        const double scaleJ = incJ / (k * binWidthJ);
+
+        // The I=J-90 (left-handed) method only differs from the I=J+90
+        // (right-handed) one by the sign of the I-axis.
+        const double signI =
+            (methodEPSGCode == EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90)
+                ? 1.0
+                : -1.0;
+
+        const double s11 = signI * scaleI * cos(theta);
+        const double s12 = -signI * scaleI * sin(theta);
+        const double s21 = scaleJ * sin(theta);
+        const double s22 = scaleJ * cos(theta);
+
+        // The map grid coordinates of the bin grid origin must map to
+        // (I0, J0), hence those offsets.
+        const double xoff = I0 - (s11 * E0 + s12 * N0);
+        const double yoff = J0 - (s21 * E0 + s22 * N0);
+
+        // Bring the map grid coordinates to easting/northing in metre, as
+        // assumed by the above coefficients.
+        auto sourceCRSProj =
+            dynamic_cast<const crs::ProjectedCRS *>(sourceCRS().get());
+        if (sourceCRSProj) {
+            formatter->startInversion();
+            sourceCRSProj->addUnitConvertAndAxisSwap(formatter, false);
+            formatter->stopInversion();
+        }
+
+        // The target CRS holds bin numbers, which are unit-less, so no unit
+        // conversion is applied on the output of the affine step.
+        formatter->addStep("affine");
+        formatter->addParam("xoff", xoff);
+        formatter->addParam("s11", s11);
+        formatter->addParam("s12", s12);
+        formatter->addParam("yoff", yoff);
+        formatter->addParam("s21", s21);
+        formatter->addParam("s22", s22);
+
+        return true;
+    }
+
     if (isAxisOrderReversal(methodEPSGCode)) {
         formatter->addStep("axisswap");
         formatter->addParam("order", "2,1");

--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -3404,7 +3404,8 @@ bool SingleOperation::exportToPROJStringGeneric(
         const double N0 =
             parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_NORTHING,
                                   common::UnitOfMeasure::METRE);
-        const double k = parameterValueNumericAsSI(
+        // Point scale factor of the map grid at a chosen reference point.
+        const double SF = parameterValueNumericAsSI(
             EPSG_CODE_PARAMETER_SCALE_FACTOR_OF_BIN_GRID);
         const double binWidthI =
             parameterValueNumeric(EPSG_CODE_PARAMETER_BIN_WIDTH_ON_I_AXIS,
@@ -3420,15 +3421,15 @@ bool SingleOperation::exportToPROJStringGeneric(
         const double incJ = parameterValueNumericAsSI(
             EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS);
 
-        if (k == 0.0 || binWidthI == 0.0 || binWidthJ == 0.0) {
+        if (SF == 0.0 || binWidthI == 0.0 || binWidthJ == 0.0) {
             throw io::FormattingException(
                 "Invalid seismic bin grid operation: the scale factor of the "
                 "bin grid and the bin widths must be non-zero");
         }
 
         // Number of bin grid units per map grid unit, along each bin grid axis.
-        const double scaleI = incI / (k * binWidthI);
-        const double scaleJ = incJ / (k * binWidthJ);
+        const double scaleI = incI / (SF * binWidthI);
+        const double scaleJ = incJ / (SF * binWidthJ);
 
         // The I=J-90 (left-handed) method only differs from the I=J+90
         // (right-handed) one by the sign of the I-axis.
@@ -3458,7 +3459,12 @@ bool SingleOperation::exportToPROJStringGeneric(
         }
 
         // The target CRS holds bin numbers, which are unit-less, so no unit
-        // conversion is applied on the output of the affine step.
+        // conversion is applied on the output of the affine step. Bin numbers
+        // are not rounded either: EPSG defines bin grid coordinate systems
+        // with a real datatype (e.g. EPSG:1051) as well as with an integer one
+        // (e.g. EPSG:32760), so whether they are whole values is a property of
+        // the bin grid coordinate system, not of these methods. Rounding here
+        // would also make the operation non-invertible.
         formatter->addStep("affine");
         formatter->addParam("xoff", xoff);
         formatter->addParam("s11", s11);

--- a/src/proj_constants.h
+++ b/src/proj_constants.h
@@ -952,6 +952,49 @@
 
 /* ------------------------------------------------------------------------ */
 
+#define EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90 9666
+#define EPSG_NAME_METHOD_SEISMIC_BIN_GRID_I_EQ_J_PLUS_90                       \
+    "P6 I=J+90 seismic bin grid coordinate operation"
+
+#define EPSG_CODE_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90 1049
+#define EPSG_NAME_METHOD_SEISMIC_BIN_GRID_I_EQ_J_MINUS_90                      \
+    "P6 I=J-90 seismic bin grid coordinate operation"
+
+#define EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_I "Bin grid origin I"
+#define EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_I 8733
+
+#define EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_J "Bin grid origin J"
+#define EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_J 8734
+
+#define EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_EASTING "Bin grid origin Easting"
+#define EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_EASTING 8735
+
+#define EPSG_NAME_PARAMETER_BIN_GRID_ORIGIN_NORTHING "Bin grid origin Northing"
+#define EPSG_CODE_PARAMETER_BIN_GRID_ORIGIN_NORTHING 8736
+
+#define EPSG_NAME_PARAMETER_SCALE_FACTOR_OF_BIN_GRID "Scale factor of bin grid"
+#define EPSG_CODE_PARAMETER_SCALE_FACTOR_OF_BIN_GRID 8737
+
+#define EPSG_NAME_PARAMETER_BIN_WIDTH_ON_I_AXIS "Bin width on I-axis"
+#define EPSG_CODE_PARAMETER_BIN_WIDTH_ON_I_AXIS 8738
+
+#define EPSG_NAME_PARAMETER_BIN_WIDTH_ON_J_AXIS "Bin width on J-axis"
+#define EPSG_CODE_PARAMETER_BIN_WIDTH_ON_J_AXIS 8739
+
+#define EPSG_NAME_PARAMETER_MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS                \
+    "Map grid bearing of bin grid J-axis"
+#define EPSG_CODE_PARAMETER_MAP_GRID_BEARING_OF_BIN_GRID_J_AXIS 8740
+
+#define EPSG_NAME_PARAMETER_BIN_NODE_INCREMENT_ON_I_AXIS                       \
+    "Bin node increment on I-axis"
+#define EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_I_AXIS 8741
+
+#define EPSG_NAME_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS                       \
+    "Bin node increment on J-axis"
+#define EPSG_CODE_PARAMETER_BIN_NODE_INCREMENT_ON_J_AXIS 8742
+
+/* ------------------------------------------------------------------------ */
+
 #define EPSG_CODE_METHOD_AXIS_ORDER_REVERSAL_2D 9843
 #define EPSG_NAME_METHOD_AXIS_ORDER_REVERSAL_2D "Axis Order Reversal (2D)"
 

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -6448,3 +6448,219 @@ TEST(operation, operation_geocen_translations_NEU_velocities_gtg) {
               "+proj=deformation +t_epoch=2000 +grids=eur_nkg_nkgrf17vel.tif "
               "+ellps=GRS80");
 }
+
+// ---------------------------------------------------------------------------
+
+TEST(operation, export_of_seismic_bin_grid_I_eq_J_plus_90) {
+
+    // EPSG:6918 "EPSG example of georeferencing I=J+90 local bin grid", whose
+    // parameters are those of the worked example of EPSG guidance note 7-2,
+    // section 2.4.3.3.
+    auto wkt =
+        "COORDINATEOPERATION[\"EPSG example of georeferencing I=J+90 local bin "
+        "grid\",\n"
+        "    VERSION[\"P6/11 I = J+90\"],\n"
+        "    SOURCECRS[\n"
+        "        PROJCRS[\"WGS 84 / UTM zone 31N\",\n"
+        "            BASEGEOGCRS[\"WGS 84\",\n"
+        "                DATUM[\"World Geodetic System 1984\",\n"
+        "                    ELLIPSOID[\"WGS 84\",6378137,298.257223563,\n"
+        "                        LENGTHUNIT[\"metre\",1]]],\n"
+        "                PRIMEM[\"Greenwich\",0,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+        "                ID[\"EPSG\",4326]],\n"
+        "            CONVERSION[\"UTM zone 31N\",\n"
+        "                METHOD[\"Transverse Mercator\",\n"
+        "                    ID[\"EPSG\",9807]],\n"
+        "                PARAMETER[\"Latitude of natural origin\",0,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                    ID[\"EPSG\",8801]],\n"
+        "                PARAMETER[\"Longitude of natural origin\",3,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                    ID[\"EPSG\",8802]],\n"
+        "                PARAMETER[\"Scale factor at natural origin\",0.9996,\n"
+        "                    SCALEUNIT[\"unity\",1],\n"
+        "                    ID[\"EPSG\",8805]],\n"
+        "                PARAMETER[\"False easting\",500000,\n"
+        "                    LENGTHUNIT[\"metre\",1],\n"
+        "                    ID[\"EPSG\",8806]],\n"
+        "                PARAMETER[\"False northing\",0,\n"
+        "                    LENGTHUNIT[\"metre\",1],\n"
+        "                    ID[\"EPSG\",8807]]],\n"
+        "            CS[Cartesian,2],\n"
+        "                AXIS[\"(E)\",east,\n"
+        "                    ORDER[1],\n"
+        "                    LENGTHUNIT[\"metre\",1]],\n"
+        "                AXIS[\"(N)\",north,\n"
+        "                    ORDER[2],\n"
+        "                    LENGTHUNIT[\"metre\",1]],\n"
+        "            ID[\"EPSG\",32631]]],\n"
+        "    TARGETCRS[\n"
+        "        ENGCRS[\"EPSG example I=J+90 local bin grid (integer "
+        "values)\",\n"
+        "            EDATUM[\"Bin grid origin\"],\n"
+        "            CS[ordinal,2],\n"
+        "                AXIS[\"bin grid I (I)\",columnPositive,\n"
+        "                    ORDER[1]],\n"
+        "                AXIS[\"bin grid J (J)\",rowPositive,\n"
+        "                    ORDER[2]],\n"
+        "            ID[\"EPSG\",32764]]],\n"
+        "    METHOD[\"P6 I=J+90 seismic bin grid coordinate operation\",\n"
+        "        ID[\"EPSG\",9666]],\n"
+        "    PARAMETER[\"Bin grid origin I\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8733]],\n"
+        "    PARAMETER[\"Bin grid origin J\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8734]],\n"
+        "    PARAMETER[\"Bin grid origin Easting\",456781,\n"
+        "        LENGTHUNIT[\"metre\",1],\n"
+        "        ID[\"EPSG\",8735]],\n"
+        "    PARAMETER[\"Bin grid origin Northing\",5836723,\n"
+        "        LENGTHUNIT[\"metre\",1],\n"
+        "        ID[\"EPSG\",8736]],\n"
+        "    PARAMETER[\"Scale factor of bin grid\",0.99984,\n"
+        "        SCALEUNIT[\"unity\",1],\n"
+        "        ID[\"EPSG\",8737]],\n"
+        "    PARAMETER[\"Bin width on I-axis\",25,\n"
+        "        LENGTHUNIT[\"metre\",1],\n"
+        "        ID[\"EPSG\",8738]],\n"
+        "    PARAMETER[\"Bin width on J-axis\",12.5,\n"
+        "        LENGTHUNIT[\"metre\",1],\n"
+        "        ID[\"EPSG\",8739]],\n"
+        "    PARAMETER[\"Map grid bearing of bin grid J-axis\",20,\n"
+        "        ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "        ID[\"EPSG\",8740]],\n"
+        "    PARAMETER[\"Bin node increment on I-axis\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8741]],\n"
+        "    PARAMETER[\"Bin node increment on J-axis\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8742]],\n"
+        "    ID[\"EPSG\",6918]]";
+
+    auto obj = WKTParser().createFromWKT(wkt);
+    auto transf = nn_dynamic_pointer_cast<Transformation>(obj);
+    ASSERT_TRUE(transf != nullptr);
+
+    // With those coefficients, map grid easting/northing (456781, 5836723)
+    // maps to bin (1, 1) and (464855.62, 5837055.90) to bin (300, 247), which
+    // are the values of the worked example of EPSG guidance note 7-2.
+    EXPECT_EQ(transf->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=affine +xoff=62692.7547606425 +s11=0.0375937198266086 "
+              "+s12=-0.0136829950122287 +yoff=-451347.522624406 "
+              "+s21=0.0273659900244574 +s22=0.0751874396532172");
+}
+
+// ---------------------------------------------------------------------------
+
+TEST(operation, export_of_seismic_bin_grid_I_eq_J_minus_90) {
+
+    // EPSG:6919 "EPSG example of georeferencing I=J-90 local bin grid", whose
+    // parameters are those of the worked example of EPSG guidance note 7-2,
+    // section 2.4.3.3. Its source CRS is expressed in US survey foot, which
+    // exercises the unit conversion of the map grid.
+    auto wkt =
+        "COORDINATEOPERATION[\"EPSG example of georeferencing I=J-90 local bin "
+        "grid\",\n"
+        "    VERSION[\"P6/11 I = J-90\"],\n"
+        "    SOURCECRS[\n"
+        "        PROJCRS[\"NAD27 / BLM 16N (ftUS)\",\n"
+        "            BASEGEOGCRS[\"NAD27\",\n"
+        "                DATUM[\"North American Datum 1927\",\n"
+        "                    ELLIPSOID[\"Clarke 1866\",6378206.4,"
+        "294.978698213,\n"
+        "                        LENGTHUNIT[\"metre\",1]]],\n"
+        "                PRIMEM[\"Greenwich\",0,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433]],\n"
+        "                ID[\"EPSG\",4267]],\n"
+        "            CONVERSION[\"BLM zone 16N (US survey foot)\",\n"
+        "                METHOD[\"Transverse Mercator\",\n"
+        "                    ID[\"EPSG\",9807]],\n"
+        "                PARAMETER[\"Latitude of natural origin\",0,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                    ID[\"EPSG\",8801]],\n"
+        "                PARAMETER[\"Longitude of natural origin\",-87,\n"
+        "                    ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "                    ID[\"EPSG\",8802]],\n"
+        "                PARAMETER[\"Scale factor at natural origin\",0.9996,\n"
+        "                    SCALEUNIT[\"unity\",1],\n"
+        "                    ID[\"EPSG\",8805]],\n"
+        "                PARAMETER[\"False easting\",1640416.67,\n"
+        "                    LENGTHUNIT[\"US survey foot\","
+        "0.304800609601219],\n"
+        "                    ID[\"EPSG\",8806]],\n"
+        "                PARAMETER[\"False northing\",0,\n"
+        "                    LENGTHUNIT[\"US survey foot\","
+        "0.304800609601219],\n"
+        "                    ID[\"EPSG\",8807]]],\n"
+        "            CS[Cartesian,2],\n"
+        "                AXIS[\"(E)\",east,\n"
+        "                    ORDER[1],\n"
+        "                    LENGTHUNIT[\"US survey foot\","
+        "0.304800609601219]],\n"
+        "                AXIS[\"(N)\",north,\n"
+        "                    ORDER[2],\n"
+        "                    LENGTHUNIT[\"US survey foot\","
+        "0.304800609601219]],\n"
+        "            ID[\"EPSG\",32066]]],\n"
+        "    TARGETCRS[\n"
+        "        ENGCRS[\"EPSG example I=J-90 local bin grid (integer "
+        "values)\",\n"
+        "            EDATUM[\"Bin grid origin\"],\n"
+        "            CS[ordinal,2],\n"
+        "                AXIS[\"bin grid I (I)\",columnNegative,\n"
+        "                    ORDER[1]],\n"
+        "                AXIS[\"bin grid J (J)\",rowPositive,\n"
+        "                    ORDER[2]],\n"
+        "            ID[\"EPSG\",32765]]],\n"
+        "    METHOD[\"P6 I=J-90 seismic bin grid coordinate operation\",\n"
+        "        ID[\"EPSG\",1049]],\n"
+        "    PARAMETER[\"Bin grid origin I\",5000,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8733]],\n"
+        "    PARAMETER[\"Bin grid origin J\",0,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8734]],\n"
+        "    PARAMETER[\"Bin grid origin Easting\",871200,\n"
+        "        LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "        ID[\"EPSG\",8735]],\n"
+        "    PARAMETER[\"Bin grid origin Northing\",10280160,\n"
+        "        LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "        ID[\"EPSG\",8736]],\n"
+        "    PARAMETER[\"Scale factor of bin grid\",1,\n"
+        "        SCALEUNIT[\"unity\",1],\n"
+        "        ID[\"EPSG\",8737]],\n"
+        "    PARAMETER[\"Bin width on I-axis\",82.5,\n"
+        "        LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "        ID[\"EPSG\",8738]],\n"
+        "    PARAMETER[\"Bin width on J-axis\",41.25,\n"
+        "        LENGTHUNIT[\"US survey foot\",0.304800609601219],\n"
+        "        ID[\"EPSG\",8739]],\n"
+        "    PARAMETER[\"Map grid bearing of bin grid J-axis\",340,\n"
+        "        ANGLEUNIT[\"degree\",0.0174532925199433],\n"
+        "        ID[\"EPSG\",8740]],\n"
+        "    PARAMETER[\"Bin node increment on I-axis\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8741]],\n"
+        "    PARAMETER[\"Bin node increment on J-axis\",1,\n"
+        "        SCALEUNIT[\"bin\",1],\n"
+        "        ID[\"EPSG\",8742]],\n"
+        "    ID[\"EPSG\",6919]]";
+
+    auto obj = WKTParser().createFromWKT(wkt);
+    auto transf = nn_dynamic_pointer_cast<Transformation>(obj);
+    ASSERT_TRUE(transf != nullptr);
+
+    // With those coefficients, map grid easting/northing (871200, 10280160)
+    // ftUS maps to bin (5000, 0) and (890972.63, 10298199.29) ftUS to bin
+    // (4700, 247), which are the values of the worked example of EPSG
+    // guidance note 7-2.
+    EXPECT_EQ(transf->exportToPROJString(PROJStringFormatter::create().get()),
+              "+proj=pipeline "
+              "+step +proj=unitconvert +xy_in=us-ft +xy_out=m "
+              "+step +proj=affine +xoff=57541.6000950241 "
+              "+s11=-0.0373693924043851 +s12=-0.0136013465078097 "
+              "+yoff=-226962.970754743 +s21=-0.0272026930156193 "
+              "+s22=0.0747387848087701");
+}


### PR DESCRIPTION
Implements the two seismic bin grid coordinate operation methods requested in #4097, following the structure of 4d64a35 (EPSG:9656 Cartesian Grid Offsets).

Both methods reduce to a single +proj=affine step, differing only in the sign of the first matrix row. EPSG declares these operations from the map grid (source) to the bin grid (target), which is the opposite direction to how the formulas are written in guidance note 7-2, so the implemented formula is the guidance note's reverse one.

Validated against EPSG's own worked examples (transformations 6918 and 6919, conversions 32698 and 32699). The I=J−90 example uses a ftUS map grid, which exercises the unit conversion path.

Not included: the four EPSG records themselves. Importing them needs conversion_table widened from 7 to 10 parameters and other_transformation from 9 to 10, a DATABASE.LAYOUT.VERSION.MINOR bump and a full data/sql regeneration. Since all four are placeholder examples ("enter here applicable extent"), they were deliberately left out.
