### PR TITLE
Polyhedral default values for cppcheck

### DIFF
--- a/src/projections/polyhedral/conway.h
+++ b/src/projections/polyhedral/conway.h
@@ -18,7 +18,7 @@ template <int NumVertices, int NumFaces, int NumFaceVertices> struct Mesh {
     // List of vertices as 3D vectors
     Vec3 vertices[NumVertices];
     // Faces, indexing above vertices
-    int faces[NumFaces][NumFaceVertices];
+    int faces[NumFaces][NumFaceVertices] = {};
 };
 
 // ConwayMode:

--- a/src/projections/polyhedral/snyder.h
+++ b/src/projections/polyhedral/snyder.h
@@ -69,11 +69,11 @@
 namespace polyhedral {
 
 struct Face2D {
-    double x, y;
+    double x = 0.0, y = 0.0;
 };
 
 struct Barycentric {
-    double u, v, w;
+    double u = 0.0, v = 0.0, w = 0.0;
 };
 
 struct FaceTriangle {
@@ -84,7 +84,7 @@ struct SphericalTriangle {
     Vec3 a, b, c;
 };
 
-inline Barycentric face_to_barycentric(Face2D p, FaceTriangle tri) {
+inline Barycentric face_to_barycentric(Face2D p, const FaceTriangle &tri) {
     double d31[2] = {tri.a.x - tri.c.x, tri.a.y - tri.c.y};
     double d23[2] = {tri.c.x - tri.b.x, tri.c.y - tri.b.y};
     double d3p[2] = {p.x - tri.c.x, p.y - tri.c.y};
@@ -96,7 +96,8 @@ inline Barycentric face_to_barycentric(Face2D p, FaceTriangle tri) {
     return {b0, b1, b2};
 }
 
-inline Face2D barycentric_to_face(Barycentric b, FaceTriangle tri) {
+inline Face2D barycentric_to_face(const Barycentric &b,
+                                  const FaceTriangle &tri) {
     return {b.u * tri.a.x + b.v * tri.b.x + b.w * tri.c.x,
             b.u * tri.a.y + b.v * tri.b.y + b.w * tri.c.y};
 }

--- a/src/projections/polyhedral/state.h
+++ b/src/projections/polyhedral/state.h
@@ -26,35 +26,35 @@ namespace polyhedral {
 constexpr int MAX_TRIANGLES = 120;
 
 struct pj_polyhedral_data {
-    int n_triangles;
-    int face_vertex_count; // NFV: 3 for triangular faces, 5 for pentagonal
-    int num_faces;
+    int n_triangles = 0;
+    int face_vertex_count = 0; // NFV: 3 for triangular faces, 5 for pentagonal
+    int num_faces = 0;
 
     SphericalTriangle sph_tris[MAX_TRIANGLES];
     FaceTriangle face_tris[MAX_TRIANGLES];
 
-    double orient[3][3];
-    double orient_inv[3][3];
+    double orient[3][3] = {};
+    double orient_inv[3][3] = {};
 
-    int root_face_index; // unfold-tree root; default reference face for
-                         // lat_0/lon_0
+    int root_face_index = 0; // unfold-tree root; default reference face for
+                             // lat_0/lon_0
 
     // Translation in projected space so the geographic anchor named by
     // +lat_0 / +lon_0 (or its dynamic default) lands at (0, 0).
     // +x_0/+y_0 stack on top via PROJ core.
-    double x_offset;
-    double y_offset;
+    double x_offset = 0.0;
+    double y_offset = 0.0;
 
     // Authalic latitude state (ellipsoidal case only; apa is null on spheres).
-    double *apa;
-    double qp;
+    double *apa = nullptr;
+    double qp = 0.0;
 
     // Linear scale applied to the (unit-net) projected coordinates so the
     // result is expressed on the authalic sphere. PROJ's core then multiplies
     // by P->a, yielding an absolute scale of a*rq = R_authalic and thus true
     // equal area on the ellipsoid. rq = sqrt(0.5*qp) = R_authalic/a on an
     // ellipsoid, and exactly 1 on a sphere (leaving the +R path unchanged).
-    double rq;
+    double rq = 1.0;
 };
 
 // Projected origin location on chosen reference face when the user does not
@@ -71,9 +71,9 @@ enum class DefaultOrigin {
 // projections). User-supplied +orient_lat is geodetic and gets converted to
 // authalic before use. On a sphere the two are identical.
 struct PolyhedralDefaults {
-    double orient_lat_deg;
-    double orient_lon_deg;
-    double azi_deg;
+    double orient_lat_deg = 0.0;
+    double orient_lon_deg = 0.0;
+    double azi_deg = 0.0;
     DefaultOrigin default_origin = DefaultOrigin::FaceCentroid;
 };
 


### PR DESCRIPTION
@rouault https://github.com/OSGeo/PROJ/pull/4758 has introduced breakages in the [CI](https://github.com/OSGeo/PROJ/actions/runs/31687740193/job/94407687436) due to `cppcheck`.

They are fixed by adding some default values. Repro'd and verified locally by running :

```bash
cppcheck --inline-suppr --template='{file}:{line},{severity},{id},{message}' \
   --enable=all --inconclusive --library=posix \
  -DCPPCHECK -D__cplusplus=201103L -DNAN \
  -Isrc -Iinclude \
  src/projections/polyhedral.cpp 2>&1 \
  | grep -Ei 'uninitMemberVar|passedByValue|knownConditionTrueFalse'

```

(`scripts/cppcheck.sh` isn't working for me)
