### PR TITLE
Add 'compiler-rt' to macOS environment.yml

### DIFF
--- a/.github/workflows/mac/environment.yml
+++ b/.github/workflows/mac/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - conda
   - mamba
   - compilers
+  - compiler-rt
   - ninja
   - cmake
   - pkg-config


### PR DESCRIPTION
 - [x] AI (Copilot or something similar) supported my development of this PR. See our [policy about AI tool use](https://proj.org/community/ai_tool_policy.html). Use of AI tools *must* be indicated.
- [ ] Closes #xxxx
- [ ] Tests added
- [ ] Added clear title that can be used to generate release notes
- [ ] Fully documented, including updating `docs/source/*.rst` for new API

https://lists.osgeo.org/pipermail/proj/2026-August/012160.html

`___divdc3` needs the run-time library to be linked.

Apparently it was compiling with clang 21.1.0. Once compiler-rt was added, it uses 21.1.8, that probably fixes some other problems, like the char comparison warning.

Gemini was used to understand the error message and the clang behavior with `___divdc3`. I never developed for macOS. Finally it was only useful suggesting changes in environment.yml.
