### PR TITLE
test_tmerczoned: make sure PJ_COORD z and t components are initialized to avoid flaky tests (master only)

### DIFF
--- a/test/unit/test_tmerczoned.cpp
+++ b/test/unit/test_tmerczoned.cpp
@@ -1,4 +1,5 @@
 #include "proj.h"
+#include <math.h>
 
 #include "gtest_include.h"
 
@@ -13,6 +14,8 @@ void test_all_zones(const char *target, const PJ_COORD expected_geographic,
     constexpr double easting_offset = 1e6;
 
     auto in_fwd = expected_geographic;
+    in_fwd.v[2] = 0;
+    in_fwd.v[3] = HUGE_VAL;
     for (int zone = 1; zone < 61; ++zone) {
         // Offset the test longitude to the specific zone.
         in_fwd.lp.phi = expected_geographic.lp.phi + (zone - 1) * zone_width;
@@ -40,6 +43,8 @@ TEST(tmerczoned, west_boundary_equator_32600) {
     PJ_COORD test;
     test.lp.lam = 0.0;
     test.lp.phi = -180.0;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 166021.4431;
@@ -52,6 +57,8 @@ TEST(tmerczoned, west_boundary_high_latitude_32600) {
     PJ_COORD test;
     test.lp.lam = 80.0;
     test.lp.phi = -180.0;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 441867.7849;
@@ -64,6 +71,8 @@ TEST(tmerczoned, east_boundary_equator_32600) {
     PJ_COORD test;
     test.lp.lam = 0.0;
     test.lp.phi = -174.000000001;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 833978.5568;
@@ -76,6 +85,8 @@ TEST(tmerczoned, east_boundary_high_latitude_32600) {
     PJ_COORD test;
     test.lp.lam = 80.0;
     test.lp.phi = -174.000000001;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 558132.2151;
@@ -88,6 +99,8 @@ TEST(tmerczoned, west_boundary_equator_32700) {
     PJ_COORD test;
     test.lp.lam = 0.0;
     test.lp.phi = -180.0;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 166021.4431;
@@ -100,6 +113,8 @@ TEST(tmerczoned, west_boundary_low_latitude_32700) {
     PJ_COORD test;
     test.lp.lam = -80.0;
     test.lp.phi = -180.0;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 441867.7849;
@@ -112,6 +127,8 @@ TEST(tmerczoned, east_boundary_equator_32700) {
     PJ_COORD test;
     test.lp.lam = 0.0;
     test.lp.phi = -174.000000001;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 833978.5568;
@@ -124,6 +141,8 @@ TEST(tmerczoned, east_boundary_low_latitude_32700) {
     PJ_COORD test;
     test.lp.lam = -80.0;
     test.lp.phi = -174.000000001;
+    test.v[2] = 0;
+    test.v[3] = HUGE_VAL;
 
     PJ_COORD expected;
     expected.xy.x = 558132.2151;


### PR DESCRIPTION
Fixes #4814

Fixes following Valgrind warning:
```
==3883492== Conditional jump or move depends on uninitialised value(s)
==3883492==    at 0x4998B61: pj_coord_has_nans (trans.cpp:43)
==3883492==    by 0x4998B61: proj_trans (trans.cpp:352)
==3883492==    by 0x1187BE: (anonymous namespace)::test_all_zones(char const*, PJ_COORD, PJ_COORD) [clone .isra.0] (test_tmerczoned.cpp:21)
==3883492==    by 0x118DF6: tmerczoned_west_boundary_equator_32600_Test::TestBody() (test_tmerczoned.cpp:48)
==3883492==    by 0x15081E: void testing::internal::HandleExceptionsInMethodIfSupported<testing::Test, void>(testing::Test*, void (testing::Test::*)(), char const*) (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x1370D5: testing::Test::Run() (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x137294: testing::TestInfo::Run() (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x13747E: testing::TestSuite::Run() (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x1452EB: testing::internal::UnitTestImpl::RunAllTests() (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x150EF6: bool testing::internal::HandleExceptionsInMethodIfSupported<testing::internal::UnitTestImpl, bool>(testing::internal::UnitTestImpl*, bool (testing::internal::UnitTestImpl::*)(), char const*) (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x137677: testing::UnitTest::Run() (in /home/even/proj/proj/build_cmake/bin/test_tmerczoned)
==3883492==    by 0x1178DA: RUN_ALL_TESTS (gtest.h:2317)
==3883492==    by 0x1178DA: main (main.cpp:38)
```
