### PR TITLE
Pick a supported size for a wiki figure

### DIFF
--- a/docs/source/geodesic.rst
+++ b/docs/source/geodesic.rst
@@ -25,7 +25,7 @@ points.  In this figure, we have :math:`\lambda_{12}=\lambda_2-\lambda_1`.
        <center>
          <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Geodesic_problem_on_an_ellipsoid.svg/330px-Geodesic_problem_on_an_ellipsoid.svg.png"
               alt="Figure from wikipedia"
-              width="320">
+              width="330">
        </center>
 
 A geodesic can be extended indefinitely by requiring that any

--- a/docs/source/geodesic.rst
+++ b/docs/source/geodesic.rst
@@ -23,7 +23,7 @@ points.  In this figure, we have :math:`\lambda_{12}=\lambda_2-\lambda_1`.
     .. raw:: html
 
        <center>
-         <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Geodesic_problem_on_an_ellipsoid.svg/320px-Geodesic_problem_on_an_ellipsoid.svg.png"
+         <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/cb/Geodesic_problem_on_an_ellipsoid.svg/330px-Geodesic_problem_on_an_ellipsoid.svg.png"
               alt="Figure from wikipedia"
               width="320">
        </center>


### PR DESCRIPTION
<!-- Feel free to remove check-list items aren't relevant to your change -->

 This is a trivial fix needed because Wikimedia now offers a limited set of image sizes.