### PR TITLE
CI: replace ilammy/msvc-dev-cmd action with TheMrMilchmann/setup-msvc-dev

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -42,7 +42,9 @@ jobs:
           python-version: "3.x"
       - run: pip install pyyaml
 
-      - uses: ilammy/msvc-dev-cmd@v1
+      - uses: TheMrMilchmann/setup-msvc-dev@v4
+        with:
+          arch: ${{ env.ARCH }}
 
       - name: Cache vcpkg packages
         uses: actions/cache@v6.1.0


### PR DESCRIPTION
It seems that [ilammy/msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) is unmaintained (e.g. shows "Node 20 is being deprecated" warnings that have been unaddressed upstream).
A maintained fork is [TheMrMilchmann/setup-msvc-dev](https://github.com/TheMrMilchmann/setup-msvc-dev) which can be used as a mostly drop-in replacement except that it requires `arch` to be specified.