### PR TITLE
CI: use modern cmake features, -Werror and parallel testing

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -32,6 +32,7 @@ jobs:
         BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
         BUILD_TYPE: ${{ matrix.BUILD_TYPE }}
         CMAKE_GENERATOR: Ninja
+        CMAKE_OPTIONS: "-Werror=dev --log-level=VERBOSE"
 
     steps:
 
@@ -69,13 +70,11 @@ jobs:
             mkdir %PROJ_DB_CACHE_DIR%
             set PATH=%VCPKG_INSTALLED%\bin;%VCPKG_INSTALLED%\tools;%PATH%
             set PROJ_BUILD=%GITHUB_WORKSPACE%\build
-            mkdir %PROJ_BUILD%
-            cd %PROJ_BUILD%
             set PROJ_DIR=%GITHUB_WORKSPACE%\proj_dir
             :: Not directly linked to BUILD_SHARED_LIBS, but a way to test different C++ standard versions
             if "${{ env.BUILD_SHARED_LIBS }}"=="ON" (set CMAKE_CXX_STANDARD="-DCMAKE_CXX_STANDARD=20")
             if "${{ env.BUILD_TYPE }}"=="Release" (set CMAKE_UNITY_BUILD_OPT="-DCMAKE_UNITY_BUILD=ON")
-            cmake ^
+            cmake ${{ env.CMAKE_OPTIONS }} ^
               -D CMAKE_BUILD_TYPE="${{ env.BUILD_TYPE }}" ^
               -D BUILD_SHARED_LIBS="${{ env.BUILD_SHARED_LIBS }}" ^
               -D EXPORT_PDB="ON" ^
@@ -84,9 +83,10 @@ jobs:
               -D CMAKE_TOOLCHAIN_FILE=c:/vcpkg/scripts/buildsystems/vcpkg.cmake ^
               -D CMAKE_INSTALL_PREFIX="%PROJ_DIR%" ^
               -D PROJ_DB_CACHE_DIR=%PROJ_DB_CACHE_DIR% ^
-              %CMAKE_UNITY_BUILD_OPT% ..
-            ninja -v
-            ninja install
+              %CMAKE_UNITY_BUILD_OPT% ^
+              -S . -B %PROJ_BUILD%
+            cmake --build %PROJ_BUILD%
+            cmake --install %PROJ_BUILD%
             dir %PROJ_DIR%\bin
 
       - name: Run tests
@@ -134,6 +134,8 @@ jobs:
         BUILD_SHARED_LIBS: ${{ matrix.BUILD_SHARED_LIBS }}
         BUILD_TYPE: Release
         CMAKE_GENERATOR: "MSYS Makefiles"
+        CMAKE_OPTIONS: "-Werror=dev --log-level=VERBOSE"
+        CMAKE_BUILD_PARALLEL_LEVEL: 2
 
     steps:
 
@@ -168,10 +170,7 @@ jobs:
             ccache -s
             PROJ_BUILD=${GITHUB_WORKSPACE}/build
             PROJ_DIR=${GITHUB_WORKSPACE}/proj_dir
-            mkdir ${PROJ_BUILD}
-            cd ${PROJ_BUILD}
-
-            cmake \
+            cmake ${{ env.CMAKE_OPTIONS }} \
               -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
               -D BUILD_SHARED_LIBS=${{ env.BUILD_SHARED_LIBS }} \
               -D CMAKE_INSTALL_PREFIX="${PROJ_DIR}" \
@@ -183,15 +182,15 @@ jobs:
               -D CMAKE_CXX_STANDARD=20 \
               -D EMBED_RESOURCE_FILES=ON \
               -D USE_ONLY_EMBEDDED_RESOURCE_FILES=ON \
-              ..
-            make -j 2
+              -S . -B ${PROJ_BUILD}
+            cmake --build ${PROJ_BUILD}
 
       - name: Seond build with EMBED_RESOURCE_FILES=OFF and USE_ONLY_EMBEDDED_RESOURCE_FILES=OFF
         run: |
             PROJ_BUILD=${GITHUB_WORKSPACE}/build
             PROJ_DIR=${GITHUB_WORKSPACE}/proj_dir
             cd ${PROJ_BUILD}
-            cmake \
+            cmake ${{ env.CMAKE_OPTIONS }} \
               -D CMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }} \
               -D BUILD_SHARED_LIBS=${{ env.BUILD_SHARED_LIBS }} \
               -D CMAKE_INSTALL_PREFIX="${PROJ_DIR}" \
@@ -204,8 +203,8 @@ jobs:
               -D EMBED_RESOURCE_FILES=OFF \
               -D USE_ONLY_EMBEDDED_RESOURCE_FILES=OFF \
               ..
-            make -j 2
-            make install
+            cmake --build ${PROJ_BUILD}
+            cmake --install ${PROJ_BUILD}
             ls ${PROJ_DIR}/bin
             ccache -s
 

--- a/ci/emscripten/build_wasm.sh
+++ b/ci/emscripten/build_wasm.sh
@@ -36,6 +36,20 @@ mkdir -p ${TEMP_BUILD_DIR}
 # and some other.
 EM_PTHREADS_FLAGS="-pthread -matomics -mbulk-memory -fexceptions"
 
+cmake --version
+
+# cmake-diagnostics added with CMake 4.4
+# https://cmake.org/cmake/help/v4.4/manual/cmake-diagnostics.7.html
+CMAKE_MAJOR_MINOR=$(cmake --version | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+cmp_44=$(printf "4.4\n${CMAKE_MAJOR_MINOR}\n")
+sorted_44=$(echo "$cmp_44" | sort -V)
+if [ "$cmp_44" = "$sorted_44" ]; then  # CMake 4.4 or later
+    cmake_diagnostics=author
+else  # Before CMake 4.4
+    cmake_diagnostics=dev
+fi
+CMAKE_OPTIONS="-Werror=${cmake_diagnostics} --log-level=VERBOSE"
+
 # --- Utility Functions ---
 
 function log_step {
@@ -44,19 +58,25 @@ function log_step {
     echo ""
 }
 
-function configure_cmake {
-    # Use emcmake wrapper to correctly configure the toolchain
+function configure_cmake_c {
+    # Use emcmake wrapper to correctly configure the toolchain for C
     emcmake cmake "$@" \
+        ${CMAKE_OPTIONS} \
         -G Ninja \
         -D CMAKE_INSTALL_PREFIX="${INSTALL_DIR}" \
         -D CMAKE_BUILD_TYPE=Release \
         -D BUILD_SHARED_LIBS=OFF \
         -D CMAKE_C_FLAGS="${EM_PTHREADS_FLAGS}" \
-        -D CMAKE_CXX_FLAGS="${EM_PTHREADS_FLAGS}" \
         -D CMAKE_FIND_ROOT_PATH="${INSTALL_DIR}" \
         -D CMAKE_FIND_ROOT_PATH_MODE_PACKAGE=ONLY \
         -D CMAKE_FIND_ROOT_PATH_MODE_LIBRARY=ONLY \
         -D CMAKE_FIND_ROOT_PATH_MODE_INCLUDE=ONLY
+}
+
+function configure_cmake_c_cxx {
+    # Use emcmake wrapper to correctly configure the toolchain for C and C++
+    configure_cmake_c "$@" \
+        -D CMAKE_CXX_FLAGS="${EM_PTHREADS_FLAGS}"
 }
 
 function build_and_install {
@@ -112,7 +132,7 @@ else
     mkdir -p build_wasm
     cd build_wasm
 
-    configure_cmake .. -DZLIB_BUILD_EXAMPLES=OFF
+    configure_cmake_c .. -DZLIB_BUILD_EXAMPLES=OFF
     build_and_install
 
     # Handle case where Zlib installs as libzlibstatic.a instead of libz.a
@@ -145,7 +165,7 @@ else
 
     # Configure minimal LibTIFF: No JPEG, No LZMA, No WebP, No ZSTD.
     # Only Zlib support enabled.
-    configure_cmake .. \
+    configure_cmake_c_cxx .. \
         -D tiff-tools=OFF \
         -D tiff-tests=OFF \
         -D tiff-contrib=OFF \
@@ -231,7 +251,7 @@ else
     cd ${PROJ_BUILD_WASM_DIR}
 
     # Configure PROJ
-    configure_cmake ${PROJ_SRC_DIR} \
+    configure_cmake_c_cxx ${PROJ_SRC_DIR} \
         -D BUILD_TESTING=OFF \
         -D BUILD_APPS=OFF \
         -D ENABLE_TIFF=ON \

--- a/ci/fedora_rawhide/start.sh
+++ b/ci/fedora_rawhide/start.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-dnf install -y cmake clang ccache ninja-build sqlite-devel libtiff-devel libcurl-devel diffutils wget
+dnf install -y cmake clang ccache ninja-build sqlite-devel libtiff-devel libcurl-devel diffutils wget gtest-devel python3-pyyaml
 # For this build, install nlohmann-json so that the "use external"
 # branch is tested; the other builds use the vendored copy.
 dnf install -y nlohmann-json-devel
@@ -12,6 +12,12 @@ cd "$WORK_DIR"
 if test -f "$WORK_DIR/ccache.tar.gz"; then
     echo "Restoring ccache..."
     (cd $HOME && tar xzf "$WORK_DIR/ccache.tar.gz")
+    # temporary fix to move previous .cache to .ccache
+    if [ -d "$HOME/.cache" ] && [ ! -d "$HOME/.ccache" ]; then
+        mv "$HOME/.cache" "$HOME/.ccache"
+    fi
+else
+    mkdir -p $HOME/.ccache
 fi
 
 export CCACHE_CPP2=yes
@@ -19,23 +25,49 @@ export CCACHE_CPP2=yes
 ccache -M 500M
 ccache -s
 
-mkdir build
-cd build
+# cmake-diagnostics added with CMake 4.4
+# https://cmake.org/cmake/help/v4.4/manual/cmake-diagnostics.7.html
+CMAKE_MAJOR_MINOR=$(cmake --version | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+cmp_44=$(printf "4.4\n${CMAKE_MAJOR_MINOR}\n")
+sorted_44=$(echo "$cmp_44" | sort -V)
+if [ "$cmp_44" = "$sorted_44" ]; then  # CMake 4.4 or later
+    cmake_diagnostics=author
+else  # Before CMake 4.4
+    cmake_diagnostics=dev
+fi
+CMAKE_OPTIONS="-Werror=${cmake_diagnostics} --log-level=VERBOSE"
+
+export CMAKE_BUILD_PARALLEL_LEVEL=$(nproc)
+export CTEST_PARALLEL_LEVEL=$(nproc)
+
 echo "Build with -DEMBED_RESOURCE_FILES=ON"
-CC=clang CXX=clang++ cmake .. \
-    -DEMBED_RESOURCE_FILES=ON -DUSE_CCACHE=ON -DPROJ_DB_CACHE_DIR=$HOME/.ccache ..
-make -j$(nproc)
-ctest -j$(nproc)
+CC=clang CXX=clang++ cmake ${CMAKE_OPTIONS} \
+    -D EMBED_RESOURCE_FILES=ON \
+    -D USE_CCACHE=ON \
+    -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
+    -S . -B build
+
+cmake --build build
+
+(cd build && ctest --output-on-failure)
+rm -rf build
 
 # Try EMBED_RESOURCE_DIRECTORY option
-wget https://raw.githubusercontent.com/OSGeo/PROJ-data/refs/heads/master/us_nga/us_nga_egm96_15.tif
-wget https://cdn.proj.org/fi_nls_ykj_etrs35fin.gpkg
-mkdir grids
-mv us_nga_egm96_15.tif grids
-mv fi_nls_ykj_etrs35fin.gpkg grids
+wget -P grids https://raw.githubusercontent.com/OSGeo/PROJ-data/refs/heads/master/us_nga/us_nga_egm96_15.tif
+wget -P grids https://cdn.proj.org/fi_nls_ykj_etrs35fin.gpkg
+
 echo "Build with -DEMBED_RESOURCE_FILES=ON -DEMBED_RESOURCE_DIRECTORY=$PWD/grids"
-CC=clang CXX=clang++ cmake .. -DEMBED_RESOURCE_DIRECTORY=$PWD/grids
-make -j$(nproc)
+CC=clang CXX=clang++ cmake ${CMAKE_OPTIONS} \
+    -D EMBED_RESOURCE_FILES=ON \
+    -D EMBED_RESOURCE_DIRECTORY=$PWD/grids \
+    -D BUILD_TESTING=OFF \
+    -D USE_CCACHE=ON \
+    -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
+    -S . -B build
+
+cmake --build build
+
+cd build
 rm -rf data
 echo 49 2 0 | bin/cs2cs "WGS84 + EGM96 height" EPSG:4979
 echo 49 2 0 | bin/cs2cs "WGS84 + EGM96 height" EPSG:4979  | grep 44.643 >/dev/null || (echo "Expected 49dN 2dE 44.643 as a result" && /bin/false)
@@ -43,20 +75,29 @@ echo 0 0 0 | bin/cct +init=ITRF2000:ITRF96
 echo 0 0 0 | bin/cct +init=ITRF2000:ITRF96 | grep 0.0067 >/dev/null || (echo "Expected 0.0067 0.0061 -0.0185 as a result" && /bin/false)
 echo 3432087 6995748 0 | bin/cct +proj=tinshift +file=fi_nls_ykj_etrs35fin.gpkg
 echo 3432087 6995748 0 | bin/cct +proj=tinshift +file=fi_nls_ykj_etrs35fin.gpkg | grep 431943.0905 >/dev/null || (echo "Expected 431943.0905   6992816.7826 0 as a result" && /bin/false)
+cd ..
 
 echo "Build with -DEMBED_RESOURCE_FILES=ON -DEMBED_RESOURCE_DIRECTORY=$PWD/grids -DUSE_ONLY_EMBEDDED_RESOURCE_FILES=ON"
-CC=clang CXX=clang++ cmake .. -DEMBED_RESOURCE_DIRECTORY=$PWD/grids -DUSE_ONLY_EMBEDDED_RESOURCE_FILES=ON
-make -j$(nproc)
+CC=clang CXX=clang++ cmake ${CMAKE_OPTIONS} \
+    -D EMBED_RESOURCE_FILES=ON \
+    -D EMBED_RESOURCE_DIRECTORY=$PWD/grids \
+    -D USE_ONLY_EMBEDDED_RESOURCE_FILES=ON \
+    -D USE_CCACHE=ON \
+    -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
+    -S . -B build
+
+cmake --build build
+
+cd build
 rm -rf data
 echo 49 2 0 | bin/cs2cs "WGS84 + EGM96 height" EPSG:4979
 echo 49 2 0 | bin/cs2cs "WGS84 + EGM96 height" EPSG:4979  | grep 44.643 >/dev/null || (echo "Expected 49dN 2dE 44.643 as a result" && /bin/false)
 echo 0 0 0 | bin/cct +init=ITRF2000:ITRF96
 echo 0 0 0 | bin/cct +init=ITRF2000:ITRF96 | grep 0.0067 >/dev/null || (echo "Expected 0.0067 0.0061 -0.0185 as a result" && /bin/false)
-
 cd ..
 
 ccache -s
 
 echo "Saving ccache..."
 rm -f "$WORK_DIR/ccache.tar.gz"
-(cd $HOME && tar czf "$WORK_DIR/ccache.tar.gz" .cache)
+(cd $HOME && tar czf "$WORK_DIR/ccache.tar.gz" .ccache)

--- a/ci/install.sh
+++ b/ci/install.sh
@@ -13,8 +13,8 @@ if test "x${NPROC}" = "x"; then
         NPROC=2;
     fi
 fi
-echo "NPROC=${NPROC}"
-export MAKEFLAGS="-j ${NPROC}"
+export CMAKE_BUILD_PARALLEL_LEVEL=${NPROC}
+export CTEST_PARALLEL_LEVEL=${NPROC}
 
 # Use ccache if it's available
 if command -v ccache &> /dev/null
@@ -34,31 +34,43 @@ fi
 
 cmake --version
 
-# For some odd reason the tar xzvf $TAR_FILENAME doesn't work on Travis-CI ...
-if test "$TRAVIS" = ""; then
-    echo "Make dist tarball, and check consistency"
-    mkdir build_dist
-    cd build_dist
-    cmake -D BUILD_TESTING=OFF ..
-    make dist
-
-    TAR_FILENAME=$(ls *.tar.gz)
-    TAR_DIRECTORY=$(basename $TAR_FILENAME .tar.gz)
-    mkdir ../build_from_dist
-    cd ../build_from_dist
-    tar xvzf ../build_dist/$TAR_FILENAME
-
-    # continue build from dist tarball
-    cd $TAR_DIRECTORY
+# cmake-diagnostics added with CMake 4.4
+# https://cmake.org/cmake/help/v4.4/manual/cmake-diagnostics.7.html
+CMAKE_MAJOR_MINOR=$(cmake --version | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+cmp_44=$(printf "4.4\n${CMAKE_MAJOR_MINOR}\n")
+sorted_44=$(echo "$cmp_44" | sort -V)
+if [ "$cmp_44" = "$sorted_44" ]; then  # CMake 4.4 or later
+    cmake_diagnostics=author
+else  # Before CMake 4.4
+    cmake_diagnostics=dev
 fi
+CMAKE_OPTIONS="-Werror=${cmake_diagnostics} --log-level=VERBOSE"
+
+if test "$TRAVIS" != ""; then
+    # For some odd reason the tar xzvf $TAR_FILENAME doesn't work on Travis-CI ...
+    echo "Travis-CI install not fully supported"
+    exit 1
+fi
+
+echo "Make dist tarball, and check consistency"
+cmake ${CMAKE_OPTIONS} -D BUILD_TESTING=OFF -S . -B build_dist
+cmake --build build_dist --target dist
+
+cd build_dist
+TAR_FILENAME=$(ls *.tar.gz)
+TAR_DIRECTORY=$(basename $TAR_FILENAME .tar.gz)
+mkdir ../build_from_dist
+cd ../build_from_dist
+tar xvzf ../build_dist/$TAR_FILENAME
+
+# continue build from dist tarball
+cd $TAR_DIRECTORY
 
 # There's a nasty #define CS in a Solaris system header. Avoid being caught about that again
 CXXFLAGS="-DCS=do_not_use_CS_for_solaris_compat $CXXFLAGS"
 
 echo "Build shared ${CMAKE_BUILD_TYPE} configuration from generated tarball"
-mkdir shared_build
-cd shared_build
-cmake \
+cmake ${CMAKE_OPTIONS} \
   -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -D CMAKE_UNITY_BUILD=ON \
   -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
@@ -68,12 +80,16 @@ cmake \
   -D BUILD_SHARED_LIBS=ON \
   -D BUILD_EXAMPLES=ON \
   -D CMAKE_INSTALL_PREFIX=/tmp/proj_shared_install_from_dist \
-  ..
-make
+  -S . -B shared_build
+
+cmake --build shared_build
+
+cd shared_build
 
 # Test adding non-official file to DB
-cp data/proj.db /tmp
-cat ../data/sql/transformations_czechia_extra.sql | sqlite3 /tmp/proj.db
+# TODO: update with new example? (transformations_czechia_extra.sql is now included)
+# cp data/proj.db /tmp
+# cat ../data/sql/transformations_czechia.sql | sqlite3 /tmp/proj.db
 
 if [ "$(uname)" == "Linux" -a -f lib/libproj.so ]; then
 if objdump -TC "lib/libproj.so" | grep "elf64-x86-64">/dev/null; then
@@ -85,7 +101,7 @@ fi
 fi
 
 ctest --output-on-failure
-make install
+cmake --install .
 # find /tmp/proj_shared_install_from_dist
 $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_shared_install_from_dist shared
 if [ "$BUILD_NAME" != "osx" ]; then
@@ -96,21 +112,18 @@ else
 fi
 
 # Test install and uninstall targets with DESTDIR
-make install DESTDIR=/tmp/destdir
-make uninstall DESTDIR=/tmp/destdir
+cmake --build . --target install DESTDIR=/tmp/destdir
+cmake --build . --target uninstall DESTDIR=/tmp/destdir
 if [ ! -z "$(ls -A /tmp/destdir/tmp/proj_shared_install_from_dist)" ]; then
     echo "Directory /tmp/destdir/tmp/proj_shared_install_from_dist should be empty, but its content is:"
     find /tmp/destdir/tmp/proj_shared_install_from_dist
     exit 1
 fi
+cd ..
 
 echo "Build static ${CMAKE_BUILD_TYPE} configuration from generated tarball"
-cd ..
-mkdir static_build
-cd static_build
-# Also test setting CMAKE_INSTALL_INCLUDEDIR/CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR to absolute directories
-# and INSTALL_LEGACY_CMAKE_FILES=OFF (both are independent from static build particularities)
-cmake \
+# Also test setting INSTALL_LEGACY_CMAKE_FILES=OFF (independent from static build particularities)
+cmake ${CMAKE_OPTIONS} \
   -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
   -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
   -D USE_CCACHE=${USE_CCACHE} \
@@ -118,14 +131,16 @@ cmake \
   -D BUILD_SHARED_LIBS=OFF \
   -D INSTALL_LEGACY_CMAKE_FILES=OFF \
   -D CMAKE_INSTALL_PREFIX=/tmp/proj_static_install_from_dist \
-  -D CMAKE_INSTALL_INCLUDEDIR=/tmp/proj_static_install_from_dist/include \
-  -D CMAKE_INSTALL_LIBDIR=/tmp/proj_static_install_from_dist/lib \
-  -D CMAKE_INSTALL_BINDIR=/tmp/proj_static_install_from_dist/bin \
-  ..
-make
+  -S . -B static_build
+
+cmake --build static_build
+
+cd static_build
 
 ctest --output-on-failure
-make install
+
+cmake --install .
+
 # find /tmp/proj_static_install_from_dist
 $TRAVIS_BUILD_DIR/test/postinstall/test_cmake.sh /tmp/proj_static_install_from_dist static PROJ_CONFIG
 if [ "$BUILD_NAME" != "osx" ]; then
@@ -137,8 +152,9 @@ fi
 
 # Re-run by unsetting CMAKE_INSTALL_INCLUDEDIR/CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR
 # so that later test which involve renaming/moving the installation prefix work.
-cmake -UCMAKE_INSTALL_INCLUDEDIR -UCMAKE_INSTALL_LIBDIR -UCMAKE_INSTALL_BINDIR ..
-make install
+echo "Build static again, unsetting a few options"
+cmake ${CMAKE_OPTIONS} -U CMAKE_INSTALL_INCLUDEDIR -U CMAKE_INSTALL_LIBDIR -U CMAKE_INSTALL_BINDIR ..
+cmake --install .
 
 echo "Run PROJJSON tests only with shared configuration"
 
@@ -246,30 +262,30 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
     echo '#include "proj.h"' > mytest.c
     echo 'int main() { proj_info(); return 0; }' >> mytest.c
 
-    echo 'cmake_minimum_required(VERSION 3.9)' > CMakeLists.txt
+    echo 'cmake_minimum_required(VERSION 3.22.1)' > CMakeLists.txt
     echo 'project(mytest)' >> CMakeLists.txt
     echo 'add_subdirectory(external/PROJ)' >> CMakeLists.txt
     echo 'add_executable(mytest mytest.c)' >> CMakeLists.txt
     echo 'target_include_directories(mytest PRIVATE $<TARGET_PROPERTY:PROJ::proj,INTERFACE_INCLUDE_DIRECTORIES>)' >> CMakeLists.txt
     echo 'target_link_libraries(mytest PRIVATE PROJ::proj)' >> CMakeLists.txt
 
-    mkdir build_cmake
-    cd build_cmake
-    cmake -D USE_CCACHE=${USE_CCACHE} -D PROJ_DB_CACHE_DIR=$HOME/.ccache ..
-    make
+    cmake ${CMAKE_OPTIONS} \
+        -D BUILD_TESTING=OFF \
+        -D USE_CCACHE=${USE_CCACHE} \
+        -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
+        -S . -B build_cmake
+
+    cmake --build build_cmake
 
     # return to root
-    cd ../..
-    if test "$TRAVIS" = ""; then
-        cd ../..
-    fi
+    cd ../../..
 
     echo "Build coverage as in-source build"
     # There's an issue with the clang on Travis + coverage + cpp code
     if [ "$BUILD_NAME" != "linux_clang" ]; then
         # build with grids and coverage
         if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-            LDFLAGS="$LDFLAGS -fprofile-arcs -ftest-coverage" cmake \
+            LDFLAGS="$LDFLAGS -fprofile-arcs -ftest-coverage" cmake ${CMAKE_OPTIONS} \
               -D CMAKE_BUILD_TYPE=Debug \
               -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -D USE_CCACHE=${USE_CCACHE} \
@@ -278,7 +294,7 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
               -D CMAKE_CXX_FLAGS="--coverage" \
               . ;
         else
-            LDFLAGS="$LDFLAGS -lgcov" cmake \
+            LDFLAGS="$LDFLAGS -lgcov" cmake ${CMAKE_OPTIONS} \
               -D CMAKE_BUILD_TYPE=Debug \
               -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
               -D USE_CCACHE=${USE_CCACHE} \
@@ -288,14 +304,14 @@ if [ "$BUILD_NAME" != "linux_gcc8" -a "$BUILD_NAME" != "linux_gcc_32bit" ]; then
               . ;
         fi
     else
-        cmake \
+        cmake ${CMAKE_OPTIONS} \
           -D CMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE} \
           -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
           -D USE_CCACHE=${USE_CCACHE} \
           -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
           . ;
     fi
-    make
+    cmake --build .
     ctest --output-on-failure
 fi
 

--- a/ci/mingw_w64/start.sh
+++ b/ci/mingw_w64/start.sh
@@ -55,10 +55,10 @@ export CC="$MINGW_ARCH-gcc"
 export CXX="$MINGW_ARCH-g++"
 export LD=$MINGW_ARCH-ld
 
-UNAME="$(uname)" || UNAME=""
-NPROC=$(nproc);
-echo "NPROC=${NPROC}"
+NPROC=$(nproc)
 export MAKEFLAGS="-j ${NPROC}"
+export CMAKE_BUILD_PARALLEL_LEVEL=${NPROC}
+export CTEST_PARALLEL_LEVEL=${NPROC}
 
 # prepare wine environment
 export WINE_PREFIX="$HOME/.wine"
@@ -94,11 +94,29 @@ tar xzf sqlite-autoconf-3330000.tar.gz
 CFLAGS="-DSQLITE_DQS=0" ./configure --host=$MINGW_ARCH --prefix=/usr/$MINGW_ARCH && make && sudo make install)
 ln -s /usr/$MINGW_ARCH/bin/libsqlite3-0.dll $WINE_SYSDIR
 
+cmake --version
+
+# cmake-diagnostics added with CMake 4.4
+# https://cmake.org/cmake/help/v4.4/manual/cmake-diagnostics.7.html
+CMAKE_MAJOR_MINOR=$(cmake --version | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+cmp_44=$(printf "4.4\n${CMAKE_MAJOR_MINOR}\n")
+sorted_44=$(echo "$cmp_44" | sort -V)
+if [ "$cmp_44" = "$sorted_44" ]; then  # CMake 4.4 or later
+    cmake_diagnostics=author
+else  # Before CMake 4.4
+    cmake_diagnostics=dev
+fi
+CMAKE_OPTIONS="-Werror=${cmake_diagnostics} --log-level=VERBOSE"
+
+# CMAKE_COMPILE_WARNING_AS_ERROR added with CMake 3.24 -- add "-Werror" for older versions
+cmp_324=$(printf "3.24\n${CMAKE_MAJOR_MINOR}\n")
+sorted_324=$(echo "$cmp_324" | sort -V)
+if [ "$cmp_324" != "$sorted_324" ]; then  # Before CMake 3.24
+    CMAKE_OPTIONS="${CMAKE_OPTIONS} -D CMAKE_C_FLAGS=\"-Werror\" -D CMAKE_CXX_FLAGS=\"-Werror\""
+fi
+
 # build proj
-rm -rf build
-mkdir build
-cd build
-cmake \
+cmake ${CMAKE_OPTIONS} \
     -G "Unix Makefiles" \
     -D CMAKE_SYSTEM_NAME=Windows \
     -D CMAKE_CROSSCOMPILING_EMULATOR=/usr/bin/wine64 \
@@ -112,14 +130,18 @@ cmake \
     -D BUILD_PROJSYNC=OFF \
     -D USE_CCACHE=ON \
     -D PROJ_DB_CACHE_DIR=$HOME/.ccache \
-    ..
-make
+    -S . -B build
+
+cmake --build build
+
+(cd build &&
 # Run a subset of tests that should pass
 ctest --output-on-failure -R "proj_test_cpp_api|geodesic-test|proj_errno_string_test|proj_angular_io_test|proj_context_test|pj_phi2_test|gie_self_tests|test_network|test_defmodel|test_tinshift|test_misc|test_fork"
 # TODO: fix failing tests with .gie files; see #2168 and run
 # PROJ_DATA=./data/for_tests wine64 ./bin/gie.exe ../test/gie/more_builtins.gie
+)
 
-make install
+cmake --install build
 
 ccache -s
 

--- a/docs/rtd/pre_build.sh
+++ b/docs/rtd/pre_build.sh
@@ -1,9 +1,13 @@
 #!/bin/sh
 set -e
 
-mkdir build
-cd build
+cmake \
+    -G Ninja \
+    -D CMAKE_BUILD_TYPE=Release \
+    -D BUILD_TESTING=OFF \
+    -D CMAKE_INSTALL_PREFIX=$HOME/.local \
+    -S . -B build
 
-cmake -GNinja -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF -DCMAKE_INSTALL_PREFIX=$HOME/.local ..
+cmake --build build
 
-ninja install
+cmake --install build

--- a/test/postinstall/c_app/CMakeLists.txt
+++ b/test/postinstall/c_app/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.22.1)
 project(C_APP LANGUAGES C)
 
 set(USE_PROJ_NAME "PROJ"

--- a/test/postinstall/test_cmake.sh
+++ b/test/postinstall/test_cmake.sh
@@ -19,13 +19,24 @@ case $3 in
   exit 1 ;;
 esac
 
+# CMake command options options differ since CMake 4.4
+CMAKE_MAJOR_MINOR=$(cmake --version | grep -o '[[:digit:]]\+\.[[:digit:]]\+')
+cmp_44=$(printf "4.4\n${CMAKE_MAJOR_MINOR}\n")
+sorted_44=$(echo "$cmp_44" | sort -V)
+if [ "$cmp_44" = "$sorted_44" ]; then  # CMake 4.4 or later
+    CMAKE_OPTIONS="-Werror=author -Wno-error=deprecated --log-level=VERBOSE"
+else  # Before CMake 4.4 - no way to supress "deprecated", so just warn
+    CMAKE_OPTIONS="-Wdev --log-level=VERBOSE"
+fi
+
+
 echo "Running post-install tests with CMake (${BUILD_MODE}, ${TESTED_CONFIGS})"
 
 
 cmake_make_ctest(){
   rm -rf build
 
-  cmake \
+  cmake ${CMAKE_OPTIONS} \
     -D CMAKE_PREFIX_PATH=${prefix} \
     -D CMAKE_COMPILE_WARNING_AS_ERROR=ON \
     -D USE_PROJ_NAME=$1 \


### PR DESCRIPTION
This is yet another CI refresh, but mostly to improve some [cmake(1)](https://cmake.org/cmake/help/v4.4/manual/cmake.1.html) features:

- Use `-Werror=dev` (cmake<4.4) or `-Werror=author` (cmake>=4.4) for CMake configure to raise errors on warnings from CMake intended for the authors (us) to see
- Try to use the `cmake -S <src-dir> -B <build-dir>` configure pattern rather than the `mkdir build && cd build && cmake ..` pattern
- Use `cmake --build <build-dir>` rather than `make` or `ninja`;  `cmake --install <build-dir>` rather than `make install`
- Use the [`CMAKE_BUILD_PARALLEL_LEVEL`](https://cmake.org/cmake/help/latest/envvar/CMAKE_BUILD_PARALLEL_LEVEL.html) env var to control the number of processors for building
- Use the [`CTEST_PARALLEL_LEVEL`](https://cmake.org/cmake/help/latest/envvar/CTEST_PARALLEL_LEVEL.html) env var to allow parallel testing

Miscellaneous changes with `ci/fedora_rawhide/start.sh`:
- Add some test dependencies
- A few cache-related fixes

Miscellaneous changes with `ci/install.sh`:
 - Raise an error if `$TRAVIS` is defined (not supported anymore), since there was special logic needed to support this
 - Disable test adding non-official file to DB, since `transformations_czechia_extra.sql` no longer exists; add TODO to potentially re-enable
 - Remove test setting CMAKE_INSTALL_INCLUDEDIR/CMAKE_INSTALL_LIBDIR/CMAKE_INSTALL_BINDIR to absolute directories, since this is discouraged (was there a use case for this?)