### PR TITLE
CMake: define target_compile_features with C/C++ standards

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,19 +25,19 @@ include(CheckCXXCompilerFlag)
 # Make CMAKE_CXX_STANDARD available as cache option overridable by user
 set(CMAKE_CXX_STANDARD 17
   CACHE STRING "C++ standard version to use (default is 17)")
-message(STATUS "Requiring C++${CMAKE_CXX_STANDARD}")
+message(CHECK_START "Requiring C++${CMAKE_CXX_STANDARD}")
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(CMAKE_CXX_EXTENSIONS OFF)
-message(STATUS "Requiring C++${CMAKE_CXX_STANDARD} - done")
+message(CHECK_PASS "done")
 
 # Set C99 version
 # Make CMAKE_C_STANDARD available as cache option overridable by user
 set(CMAKE_C_STANDARD 99
   CACHE STRING "C standard version to use (default is 99)")
-message(STATUS "Requiring C${CMAKE_C_STANDARD}")
+message(CHECK_START "Requiring C${CMAKE_C_STANDARD}")
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
-message(STATUS "Requiring C${CMAKE_C_STANDARD} - done")
+message(CHECK_PASS "done")
 
 # Set global -fvisibility=hidden
 set(CMAKE_C_VISIBILITY_PRESET hidden)

--- a/src/lib_proj.cmake
+++ b/src/lib_proj.cmake
@@ -392,6 +392,12 @@ add_library(proj
 )
 add_library(PROJ::proj ALIAS proj)
 
+target_compile_features(proj
+  PUBLIC
+    c_std_${CMAKE_C_STANDARD}
+    cxx_std_${CMAKE_CXX_STANDARD}
+)
+
 if(MSVC OR MINGW)
     target_compile_definitions(proj PRIVATE -DNOMINMAX)
 endif()


### PR DESCRIPTION
This defines the high level meta features for C/C++ support based on their standard, and set using [`target_compile_features`](https://cmake.org/cmake/help/latest/command/target_compile_features.html) to the main `proj` target. It is PUBLIC, meaning that the C/C++ standard applies to compile this library, and anything that links to it. The exported target would look like this:
```
Properties for TARGET PROJ::proj:
  PROJ::proj.LOCATION = "/tmp/proj_shared_install_from_dist/lib/libproj.so.25.9.9.0"
  PROJ::proj.INTERFACE_INCLUDE_DIRECTORIES = "/tmp/proj_shared_install_from_dist/include"
  PROJ::proj.INTERFACE_LINK_LIBRARIES = <NOTFOUND>
  PROJ::proj.INTERFACE_COMPILE_FEATURES = "c_std_99;cxx_std_17"
```

Also tidy-up some of the messages while setting the CMake standard variables. These never fail, so `message(CHECK_FAIL ...)` is not needed (the failure, e.g. non-existing standard, happens before in `project()`).

Background information [here](https://crascit.com/2015/03/28/enabling-cxx11-in-cmake/).

Xref #1924