### PR TITLE
fix residual axisswap for Geographic3D <->  VerticalCRS pipelines

### DIFF
--- a/include/proj/crs.hpp
+++ b/include/proj/crs.hpp
@@ -143,6 +143,8 @@ class PROJ_GCC_DLL CRS : public common::ObjectUsage,
 
     PROJ_INTERNAL bool mustAxisOrderBeSwitchedForVisualization() const;
 
+    PROJ_INTERNAL bool hasNoHorizontalAxes() const;
+
     PROJ_INTERNAL CRSNNPtr applyAxisOrderReversal(const char *nameSuffix) const;
 
     PROJ_FOR_TEST CRSNNPtr normalizeForVisualization() const;

--- a/src/iso19111/crs.cpp
+++ b/src/iso19111/crs.cpp
@@ -946,6 +946,31 @@ bool CRS::mustAxisOrderBeSwitchedForVisualization() const {
     return false;
 }
 
+// ---------------------------------------------------------------------------
+
+/** Return whether this CRS declares no horizontal axes.
+ *
+ * Coordinate operations involving such a CRS just pass horizontal coordinates
+ * through, so their axis order is dictated by the other end of the operation
+ * rather than by this CRS.
+ */
+bool CRS::hasNoHorizontalAxes() const {
+
+    if (dynamic_cast<const VerticalCRS *>(this)) {
+        return true;
+    }
+
+    if (const CompoundCRS *compoundCRS =
+            dynamic_cast<const CompoundCRS *>(this)) {
+        const auto &comps = compoundCRS->componentReferenceSystems();
+        if (!comps.empty()) {
+            return comps[0]->hasNoHorizontalAxes();
+        }
+    }
+
+    return false;
+}
+
 //! @endcond
 
 // ---------------------------------------------------------------------------

--- a/src/iso19111/operation/singleoperation.cpp
+++ b/src/iso19111/operation/singleoperation.cpp
@@ -422,10 +422,20 @@ CoordinateOperation::normalizeForVisualization() const {
         throw util::UnsupportedOperationException(
             "Cannot retrieve source or target CRS");
     }
-    const bool swapSource =
-        l_sourceCRS->mustAxisOrderBeSwitchedForVisualization();
-    const bool swapTarget =
-        l_targetCRS->mustAxisOrderBeSwitchedForVisualization();
+    bool swapSource = l_sourceCRS->mustAxisOrderBeSwitchedForVisualization();
+    bool swapTarget = l_targetCRS->mustAxisOrderBeSwitchedForVisualization();
+
+    // A CRS without horizontal axes lets horizontal coordinates pass through
+    // in the axis order of the other end, so both ends must be swapped
+    // together to avoid leaving a residual axis swap in the pipeline.
+    const bool sourceHasNoHorizontalAxes = l_sourceCRS->hasNoHorizontalAxes();
+    const bool targetHasNoHorizontalAxes = l_targetCRS->hasNoHorizontalAxes();
+    if (targetHasNoHorizontalAxes && !sourceHasNoHorizontalAxes) {
+        swapTarget = swapSource;
+    } else if (sourceHasNoHorizontalAxes && !targetHasNoHorizontalAxes) {
+        swapSource = swapTarget;
+    }
+
     auto l_this = NN_NO_CHECK(std::dynamic_pointer_cast<CoordinateOperation>(
         shared_from_this().as_nullable()));
     if (!swapSource && !swapTarget) {

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5732,11 +5732,10 @@ TEST(operation, normalizeForVisualization) {
         auto op = list[0];
         // Without normalization the operation carries its own axis swaps.
         EXPECT_TRUE(
-            op->exportToPROJString(
-                  PROJStringFormatter::create(
-                      PROJStringFormatter::Convention::PROJ_5,
-                      authFactory->databaseContext())
-                      .get())
+            op->exportToPROJString(PROJStringFormatter::create(
+                                       PROJStringFormatter::Convention::PROJ_5,
+                                       authFactory->databaseContext())
+                                       .get())
                 .find("+proj=axisswap +order=2,1") != std::string::npos);
         auto opNormalized = op->normalizeForVisualization();
         EXPECT_FALSE(opNormalized->_isEquivalentTo(op.get()));

--- a/test/unit/test_operation.cpp
+++ b/test/unit/test_operation.cpp
@@ -5716,6 +5716,66 @@ TEST(operation, normalizeForVisualization) {
             "+step +proj=unitconvert +xy_in=rad +xy_out=deg");
     }
 
+    // Source(geographic 3D) and target(vertical): the vertical CRS has no
+    // horizontal axes, so the horizontal coordinates it passes through must
+    // follow the source axis order. No residual axisswap must remain.
+    {
+        auto ctxt =
+            CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+        // ETRS89 (geographic 3D)
+        auto src = authFactory->createCoordinateReferenceSystem("4937");
+        // NN54 height
+        auto dst = authFactory->createCoordinateReferenceSystem("5776");
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            src, dst, ctxt);
+        ASSERT_GE(list.size(), 1U);
+        auto op = list[0];
+        // Without normalization the operation carries its own axis swaps.
+        EXPECT_TRUE(
+            op->exportToPROJString(
+                  PROJStringFormatter::create(
+                      PROJStringFormatter::Convention::PROJ_5,
+                      authFactory->databaseContext())
+                      .get())
+                .find("+proj=axisswap +order=2,1") != std::string::npos);
+        auto opNormalized = op->normalizeForVisualization();
+        EXPECT_FALSE(opNormalized->_isEquivalentTo(op.get()));
+        const auto projString = opNormalized->exportToPROJString(
+            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_5,
+                                        authFactory->databaseContext())
+                .get());
+        EXPECT_TRUE(projString.find("+proj=axisswap +order=2,1") ==
+                    std::string::npos)
+            << projString;
+        EXPECT_TRUE(projString.find("+proj=vgridshift") != std::string::npos)
+            << projString;
+    }
+
+    // Reverse of above: source(vertical) and target(geographic 3D)
+    {
+        auto ctxt =
+            CoordinateOperationContext::create(authFactory, nullptr, 0.0);
+        // NN54 height
+        auto src = authFactory->createCoordinateReferenceSystem("5776");
+        // ETRS89 (geographic 3D)
+        auto dst = authFactory->createCoordinateReferenceSystem("4937");
+        auto list = CoordinateOperationFactory::create()->createOperations(
+            src, dst, ctxt);
+        ASSERT_GE(list.size(), 1U);
+        auto op = list[0];
+        auto opNormalized = op->normalizeForVisualization();
+        EXPECT_FALSE(opNormalized->_isEquivalentTo(op.get()));
+        const auto projString = opNormalized->exportToPROJString(
+            PROJStringFormatter::create(PROJStringFormatter::Convention::PROJ_5,
+                                        authFactory->databaseContext())
+                .get());
+        EXPECT_TRUE(projString.find("+proj=axisswap +order=2,1") ==
+                    std::string::npos)
+            << projString;
+        EXPECT_TRUE(projString.find("+proj=vgridshift") != std::string::npos)
+            << projString;
+    }
+
     // Source(boundCRS) and target(geographic) must be inverted
     {
         auto src = BoundCRS::createFromTOWGS84(


### PR DESCRIPTION
## What the fix does

Fixes a bug in `CoordinateOperation::normalizeForVisualization()` (the
function behind pyproj's `always_xy=True` and `proj_normalize_for_visualization()`)
where a Geographic3D <-> VerticalCRS pipeline keeps a leftover
`+proj=axisswap +order=2,1` step. In practice this means the horizontal
coordinates come out lat/lon instead of lon/lat even though `always_xy=True`
was requested, with no warning or error.

Example: `EPSG:4937` (ETRS89, geographic 3D) -> `EPSG:5776` (NN54 height).



## Why it happens

A `VerticalCRS` has no horizontal axes, so
`CRS::mustAxisOrderBeSwitchedForVisualization()` always returns `false` for
it, which is correct on its own - there's no axis order to reverse on a 1D
CRS.

The problem is that the actual operation between a geographic and a vertical
CRS still carries a horizontal pass-through internally (built from the
geographic side on both ends of the pipeline), and that pass-through is
symmetric by construction. `normalizeForVisualization()` decides whether to
swap each end independently, so it ends up swapping only the geographic end
and leaving the vertical end alone - which breaks that symmetry and leaves
one of the two swaps stranded in the final pipeline.

## The fix

Added `CRS::hasNoHorizontalAxes()`, and in `normalizeForVisualization()`,
when exactly one end of the operation has no horizontal axes, that end now
just inherits the other end's swap decision instead of being evaluated on
its own.

I deliberately kept this at the operation level rather than touching
`mustAxisOrderBeSwitchedForVisualization()` itself, since that function is
also used to transpose area-of-use extents, and making a VerticalCRS report
`true` there would mess up bounding boxes for unrelated code paths.

## Testing
- [x] Tests added: two new cases in the existing `TEST(operation, normalizeForVisualization)` (`test/unit/test_operation.cpp`) covering `EPSG:4937 -> EPSG:5776` and its reverse, asserting no residual `axisswap` remains in the normalized pipeline

## Scope

This only covers Geographic3D <-> VerticalCRS. `EngineeringCRS` pairs with
axis directions like north/west (e.g. EPSG:5800) have a related problem, but
fixing that needs an axis *direction* flip that
`Conversion::createAxisOrderReversal` can't express today, so it's a
separate, bigger change and out of scope here.

- [x] Fixes #4848
